### PR TITLE
use yaml.safe_load instead of deprecated yaml.load

### DIFF
--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -160,7 +160,7 @@ class TestNode(unittest.TestCase):
         expanded_parameter_files = node_action._Node__expanded_parameter_files
         assert len(expanded_parameter_files) == 1
         with open(expanded_parameter_files[0], 'r') as h:
-            expanded_parameters_dict = yaml.load(h)
+            expanded_parameters_dict = yaml.safe_load(h)
             assert expanded_parameters_dict == {
                 '/my_ns': {
                     'my_node': {


### PR DESCRIPTION
**DO NOT MERGE**

This PR removes deprecation warning similarly to colcon/colcon-metadata#14.

With this change the tests are currently failing due to the use of python tuples converted to yaml in the tests.
2 options to fix it:
- use the unsafe loader: As this is only test code and the fixtures are controlled, using the unsaf loader does not pose security concerns.
- use the safe loader: this allows to use the same loader throughout the codebase, but I'm not familiar with the code here to say if the change to use only standard YAML tags is trivial or not. 
