### PR TITLE
Move OnProcessStart from LoadComposableNodes to ComposableNodeContainer

### DIFF
--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -20,9 +20,6 @@ from typing import Optional
 import composition_interfaces.srv
 
 from launch.action import Action
-from launch.actions import RegisterEventHandler
-from launch.event_handlers.on_process_start import OnProcessStart
-from launch.events.process import ProcessStarted
 from launch.launch_context import LaunchContext
 import launch.logging
 from launch.utilities import ensure_argument_type

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -48,6 +48,9 @@ class LoadComposableNodes(Action):
         The container node is expected to provide a `~/_container/load_node` service for
         loading purposes.
         Loading will be performed sequentially.
+        When executed, this action will block until the container's load service is available.
+        Make sure any LoadComposableNode action is executed only after its container processes
+        has started.
 
         :param composable_node_descriptions: descriptions of composable nodes to be loaded
         :param target_container: the container to load the nodes into

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -156,15 +156,6 @@ class LoadComposableNodes(Action):
                 )
             )
 
-    def _on_container_start(
-        self,
-        event: ProcessStarted,
-        context: LaunchContext
-    ) -> Optional[List[Action]]:
-        """Load nodes on container process start."""
-        self._load_in_sequence(self.__composable_node_descriptions, context)
-        return None
-
     def execute(
         self,
         context: LaunchContext
@@ -176,10 +167,5 @@ class LoadComposableNodes(Action):
                 self.__target_container.node_name
             )
         )
-        # Perform load action once the container has started.
-        return [RegisterEventHandler(
-            event_handler=OnProcessStart(
-                target_action=self.__target_container,
-                on_start=self._on_container_start,
-            )
-        )]
+        # Assume user has configured `LoadComposableNodes` to happen after container action
+        self._load_in_sequence(self.__composable_node_descriptions, context)


### PR DESCRIPTION
Currently `LoadComposableNodes.execute()` returns an action that loads the nodes when the container process starts. However, if the container process is already started then these loads will never be loaded because the event has already been triggered. This changes `LaunchComposableNodes.execute` to launch the nodes right away, and makes  `ComposableNodeContainer` return an action that triggers `LaunchComposableNodes` on the event `OnProcessStart`.

The result is `LoadComposableNodes` can be triggered by some event long after the container process starts.

I think this can be merged as is, though #15 has a test for this case. To run that you'll need to make local a branch with this + #8 + #15.