### PR TITLE
use local import

### DIFF
--- a/launch_testing_ros/launch_testing_ros/message_pump.py
+++ b/launch_testing_ros/launch_testing_ros/message_pump.py
@@ -14,9 +14,6 @@
 
 import threading
 
-import rclpy
-import rclpy.executors
-
 
 class MessagePump:
     """Calls rclpy.spin on a thread so tests don't need to."""
@@ -40,7 +37,8 @@ class MessagePump:
             raise Exception('Timed out waiting for message pump to stop')
 
     def _run(self):
-        executor = rclpy.executors.SingleThreadedExecutor(context=self._context)
+        from rclpy.executors import SingleThreadedExecutor
+        executor = SingleThreadedExecutor(context=self._context)
         executor.add_node(self._node)
         while self._run:
             executor.spin_once(timeout_sec=1.0)


### PR DESCRIPTION
This works around a regression from #8 which fails numerous tests on Windows debug.

Windows Debug builds testing `demo_nodes_cpp`:

* Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6689)](https://ci.ros2.org/job/ci_windows/6689/)
* After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6690)](https://ci.ros2.org/job/ci_windows/6690/)

@hidmic Let's get this reviewed and merged to address the regressions and feel free to revert the patch in a future PR with a better fix.