### PR TITLE
Launch autocomplete doesnt require dot

### DIFF
--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -79,7 +79,7 @@ def get_python_launch_file_paths(*, path):
     python_launch_file_paths = []
     for root, dirs, files in os.walk(path):
         for file_name in files:
-            if file_name.endswith('.launch.py'):
+            if file_name.endswith('launch.py'):
                 python_launch_file_paths.append(os.path.join(root, file_name))
     return python_launch_file_paths
 


### PR DESCRIPTION
Signed-off-by: Matthew Hansen <matthew.k.hansen@intel.com>

This makes autocomplete find any `*launch.py` files without the need for a dot before launch:  `*.launch.py`

All of these should work:
```
foo.launch.py
foo_launch.py
launch.py
foo-launch.py
foolaunch.py
```
@wjwwood - this is in follow up to this discourse thread:
https://discourse.ros.org/t/questioning-the-launch-py-file-extension/6352