### PR TITLE
Add custom LaunchTestRunner with ROS specific preamble

### DIFF
--- a/launch_testing_ros/launch_testing_ros/__init__.py
+++ b/launch_testing_ros/launch_testing_ros/__init__.py
@@ -16,10 +16,11 @@
 from . import tools
 from .data_republisher import DataRepublisher
 from .message_pump import MessagePump
-
+from .test_runner import LaunchTestRunner
 
 __all__ = [
     'DataRepublisher',
+    'LaunchTestRunner',
     'MessagePump',
     'tools',
 ]

--- a/launch_testing_ros/launch_testing_ros/test_runner.py
+++ b/launch_testing_ros/launch_testing_ros/test_runner.py
@@ -14,11 +14,11 @@
 
 """Module for a ROS aware LaunchTestRunner."""
 
-import rclpy
-
 import launch
 import launch_ros
 import launch_testing.test_runner
+
+import rclpy
 
 
 class LaunchTestRunner(launch_testing.test_runner.LaunchTestRunner):

--- a/launch_testing_ros/launch_testing_ros/test_runner.py
+++ b/launch_testing_ros/launch_testing_ros/test_runner.py
@@ -1,0 +1,38 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for a ROS aware LaunchTestRunner."""
+
+import rclpy
+
+import launch
+import launch_ros
+import launch_testing.test_runner
+
+
+class LaunchTestRunner(launch_testing.test_runner.LaunchTestRunner):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._rclpy_context = rclpy.context.Context()
+        rclpy.init(args=self._launch_file_arguments, context=self._rclpy_context)
+
+    def generate_preamble(self):
+        return [launch.actions.IncludeLaunchDescription(
+            launch_description_source=launch.LaunchDescriptionSource(
+                launch_description=launch_ros.get_default_launch_description(
+                    rclpy_context=self._rclpy_context,
+                )
+            )
+        )]


### PR DESCRIPTION
Connected to https://github.com/ros2/rostest/pull/1. This pull request adds a `LaunchTestRunner` subclass that injects the `launch_ros`'s default launch description as a preamble to all launch test fixtures, enabling ROS aware launch actions.