### PR TITLE
fix calling of print_arguments_of_launch_description()

### DIFF
--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -119,7 +119,7 @@ def print_arguments_of_launch_description(*, launch_description):
 def print_arguments_of_python_launch_file(*, python_launch_file_path):
     """Print the arguments of a Python launch file to the console."""
     launch_description = get_launch_description_from_python_launch_file(python_launch_file_path)
-    print_arguments_of_launch_description(launch_description)
+    print_arguments_of_launch_description(launch_description=launch_description)
 
 
 def parse_launch_arguments(launch_arguments: List[Text]) -> List[Tuple[Text, Text]]:


### PR DESCRIPTION
Without this using the `-s`/`--show-arguments` options for `ros2 launch` gave:

```
Traceback (most recent call last):
  File "/home/william/ros2_ws/install/ros2cli/bin/ros2", line 11, in <module>
    load_entry_point('ros2cli', 'console_scripts', 'ros2')()
  File "/home/william/ros2_ws/build/ros2cli/ros2cli/cli.py", line 69, in main
    rc = extension.main(parser=parser, args=args)
  File "/home/william/ros2_ws/build/ros2launch/ros2launch/command/launch.py", line 118, in main
    return print_arguments_of_python_launch_file(python_launch_file_path=path)
  File "/home/william/ros2_ws/build/ros2launch/ros2launch/api/api.py", line 122, in print_arguments_of_python_launch_file
    print_arguments_of_launch_description(launch_description)
TypeError: print_arguments_of_launch_description() takes 0 positional arguments but 1 was given
```