### PR TITLE
fix example test logic

### DIFF
--- a/launch_testing_ros/examples/talker_listener.test.py
+++ b/launch_testing_ros/examples/talker_listener.test.py
@@ -160,8 +160,7 @@ class TestTalkerListenerLink(unittest.TestCase):
             )
             if success:
                 break
-        else:
-            assert False, 'Waiting for output timed out'
+        assert success, 'Waiting for output timed out'
 
     def test_fuzzy_data(self, listener):
         # This test shows how to insert a node in between the talker and the listener to

--- a/launch_testing_ros/examples/talker_listener.test.py
+++ b/launch_testing_ros/examples/talker_listener.test.py
@@ -146,17 +146,22 @@ class TestTalkerListenerLink(unittest.TestCase):
         )
         self.addCleanup(self.node.destroy_publisher, pub)
 
-        # Publish some unique messages on /chatter and verify that the listener gets them
-        # and prints them
-        for _ in range(5):
-            msg = std_msgs.msg.String()
-            msg.data = str(uuid.uuid4())
+        # Publish a unique message on /chatter and verify that the listener
+        # gets it and prints it
+        msg = std_msgs.msg.String()
+        msg.data = str(uuid.uuid4())
+        for _ in range(10):
 
             pub.publish(msg)
-            self.proc_output.assertWaitFor(
+            success = self.proc_output.waitFor(
                 expected_output=msg.data,
-                process=listener
+                process=listener,
+                timeout=1.0,
             )
+            if success:
+                break
+        else:
+            assert False, 'Waiting for output timed out'
 
     def test_fuzzy_data(self, listener):
         # This test shows how to insert a node in between the talker and the listener to


### PR DESCRIPTION
Fixes ros2/build_cop#197.

Without the patch the publisher publishes a single message and waits for the subscriber to receive that message. Since the matching between both might not have happened the `assertWaitFor` times out after 10s and calls `assert` failing the test.

This patch relies on ros2/launch#243 and publishes 10 messages - one every second - until the listener received it.

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7143)](https://ci.ros2.org/job/ci_linux/7143/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=7145)](https://ci.ros2.org/job/ci_linux/7145/)