### PR TITLE
Parameter values get evaluated by yaml rules

### DIFF
--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -43,12 +43,12 @@ def evaluate_parameter_dict(
 ) -> Dict[str, EvaluatedParameterValue]:
     if not isinstance(parameters, Mapping):
         raise TypeError('expected dict')
-    output_dict = {}  # type: Dict[str, EvaluatedParameterValue]
+    output_dict: Dict[str, EvaluatedParameterValue] = {}
     for name, value in parameters.items():
         if not isinstance(name, tuple):
             raise TypeError('Expecting tuple of substitutions got {}'.format(repr(name)))
-        evaluated_name = perform_substitutions(context, list(name))  # type: str
-        evaluated_value = None  # type: Optional[EvaluatedParameterValue]
+        evaluated_name: str = perform_substitutions(context, list(name))
+        evaluated_value: Optional[EvaluatedParameterValue] = None
 
         if isinstance(value, tuple) and len(value):
             if isinstance(value[0], Substitution):
@@ -57,14 +57,14 @@ def evaluate_parameter_dict(
                 evaluated_value = yaml.safe_load(evaluated_value)
             elif isinstance(value[0], Sequence):
                 # Value is an array of a list of substitutions
-                output_subvalue = []  # List[str]
+                output_subvalue: List[str] = []
                 for subvalue in value:
                     value = perform_substitutions(context, list(subvalue))
                     output_subvalue.append(value)
                     evaluated_value = tuple(output_subvalue)
                 # All values in a list must have the same type.
                 # If they don't then assume it is a list of strings
-                yaml_evaluated_value = []  # Union[List[str], List[int], List[float], List[bool]]
+                yaml_evaluated_value: Union[List[str], List[int], List[float], List[bool]] = []
                 type_ = None
                 dissimilar_types = False
                 for subvalue in evaluated_value:

--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -65,16 +65,16 @@ def evaluate_parameter_dict(
                 # All values in a list must have the same type.
                 # If they don't then assume it is a list of strings
                 yaml_evaluated_value: Union[List[str], List[int], List[float], List[bool]] = []
-                type_ = None
+                last_subtype = None
                 dissimilar_types = False
                 for subvalue in evaluated_value:
                     yaml_subvalue = yaml.safe_load(subvalue)
                     subtype = type(yaml_subvalue)
-                    if type_ is not None and type_ != subtype:
+                    if last_subtype is not None and last_subtype != subtype:
                         dissimilar_types = True
                         break
                     yaml_evaluated_value.append(yaml_subvalue)
-                    type_ = subtype
+                    last_subtype = subtype
                 if not dissimilar_types:
                     evaluated_value = tuple(yaml_evaluated_value)
             else:

--- a/test_launch_ros/test/test_launch_ros/test_normalize_parameters.py
+++ b/test_launch_ros/test/test_launch_ros/test_normalize_parameters.py
@@ -75,6 +75,12 @@ def test_dictionary_with_substitution():
     expected = ({'bar': 'baz'},)
     assert evaluate_parameters(LaunchContext(), norm) == expected
 
+    # substitutions get yamlfied
+    orig = [{TextSubstitution(text='false'): TextSubstitution(text='off')}]
+    norm = normalize_parameters(orig)
+    expected = ({'false': False},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
 
 def test_dictionary_with_substitution_list_name():
     orig = [{(TextSubstitution(text='bar'), TextSubstitution(text='foo')): 1}]
@@ -92,6 +98,21 @@ def test_dictionary_with_substitution_list_value():
     orig = [{'foo': [[TextSubstitution(text='fiz')], [TextSubstitution(text='buz')]]}]
     norm = normalize_parameters(orig)
     expected = ({'foo': ('fiz', 'buz')},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+    orig = [{'bools': [[TextSubstitution(text='True')], [TextSubstitution(text='False')]]}]
+    norm = normalize_parameters(orig)
+    expected = ({'bools': (True, False)},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+    orig = [{'ints': [[TextSubstitution(text='1')], [TextSubstitution(text='2')]]}]
+    norm = normalize_parameters(orig)
+    expected = ({'ints': (1, 2)},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected
+
+    orig = [{'floats': [[TextSubstitution(text='1.0')], [TextSubstitution(text='2.0')]]}]
+    norm = normalize_parameters(orig)
+    expected = ({'floats': (1.0, 2.0)},)
     assert evaluate_parameters(LaunchContext(), norm) == expected
 
 


### PR DESCRIPTION
Resolves ros2/launch_ros#30

This PR evaluates parameter values as `yaml` would.

I'm not set up to run mypy at the moment, so I'm not confident the type annotations are correct.