### PR TITLE
Use wildcard syntax in generated parameter YAML files

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -14,7 +14,6 @@
 
 """Module for the Node action."""
 
-from collections.abc import Mapping
 import os
 import pathlib
 from tempfile import NamedTemporaryFile
@@ -139,10 +138,6 @@ class Node(ExecuteProcess):
             # evaluate to paths), or dictionaries of parameters (fields can be substitutions).
             i = 0
             for param in parameters:
-                if isinstance(param, Mapping) and node_name is None:
-                    raise RuntimeError(
-                        'If a dictionary of parameters is specified, the node name must also be '
-                        'specified. See https://github.com/ros2/launch/issues/139')
                 i += 1
                 cmd += [LocalSubstitution(
                     'ros_specific_arguments[{}]'.format(ros_args_index),
@@ -188,9 +183,7 @@ class Node(ExecuteProcess):
         with NamedTemporaryFile(mode='w', prefix='launch_params_', delete=False) as h:
             param_file_path = h.name
             # TODO(dhood): clean up generated parameter files.
-            param_dict = {self.__expanded_node_name: {'ros__parameters': params}}
-            if self.__expanded_node_namespace:
-                param_dict = {self.__expanded_node_namespace: param_dict}
+            param_dict = {'/**': {'ros__parameters': params}}
             yaml.dump(param_dict, h, default_flow_style=False)
             return param_file_path
 

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -162,14 +162,12 @@ class TestNode(unittest.TestCase):
         with open(expanded_parameter_files[0], 'r') as h:
             expanded_parameters_dict = yaml.load(h)
             assert expanded_parameters_dict == {
-                '/my_ns': {
-                    'my_node': {
-                        'ros__parameters': {
-                            'param1': 'param1_value',
-                            'param2': 'param2_value',
-                            'param_group1.list_params': (1.2, 3.4),
-                            'param_group1.param_group2.param2_values': ('param2_value',),
-                        }
+                '/**': {
+                    'ros__parameters': {
+                        'param1': 'param1_value',
+                        'param2': 'param2_value',
+                        'param_group1.list_params': (1.2, 3.4),
+                        'param_group1.param_group2.param2_values': ('param2_value',),
                     }
                 }
             }
@@ -183,13 +181,13 @@ class TestNode(unittest.TestCase):
         self._assert_type_error_creating_node(
             parameters=str(parameter_file_path))  # Valid path, but not in a list.
 
-        # If a parameter dictionary is specified, the node name must be also.
-        with self.assertRaisesRegex(RuntimeError, 'node name must also be specified'):
-            launch_ros.actions.Node(
-                package='demo_nodes_py', node_executable='talker_qos', output='screen',
-                arguments=['--number_of_cycles', '1'],
-                parameters=[{'my_param': 'value'}],
-            )
+        # If a parameter dictionary is specified, the node name is no longer required.
+        node_action = launch_ros.actions.Node(
+            package='demo_nodes_py', node_executable='talker_qos', output='screen',
+            arguments=['--number_of_cycles', '1'],
+            parameters=[{'my_param': 'value'}],
+        )
+        self._assert_launch_no_errors([node_action])
 
     def test_launch_node_with_invalid_parameter_dicts(self):
         """Test launching a node with invalid parameter dicts."""


### PR DESCRIPTION
This will eliminate the requirement that a node name override be specified when passing a dictionary of parameters from launch.

Requires ros2/rclcpp#762
Requires ros2/rclpy#370

Resolves ros2/launch_ros#4