### PR TITLE
Add PushRosNamespace action

### DIFF
--- a/launch_ros/launch_ros/actions/__init__.py
+++ b/launch_ros/launch_ros/actions/__init__.py
@@ -18,10 +18,12 @@ from .composable_node_container import ComposableNodeContainer
 from .lifecycle_node import LifecycleNode
 from .load_composable_nodes import LoadComposableNodes
 from .node import Node
+from .push_ros_namespace import PushRosNamespace
 
 __all__ = [
     'ComposableNodeContainer',
     'LifecycleNode',
     'LoadComposableNodes',
     'Node',
+    'PushRosNamespace',
 ]

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -166,7 +166,7 @@ class Node(ExecuteProcess):
         self.__arguments = arguments
 
         self.__expanded_node_name = '<node_name_unspecified>'
-        self.__expanded_node_namespace = '/'
+        self.__expanded_node_namespace = ''
         self.__final_node_name = None  # type: Optional[Text]
         self.__expanded_parameter_files = None  # type: Optional[List[Text]]
         self.__expanded_remappings = None  # type: Optional[List[Tuple[Text, Text]]]
@@ -285,7 +285,10 @@ class Node(ExecuteProcess):
                 self.__expanded_node_namespace = perform_substitutions(
                     context, normalize_to_list_of_substitutions(self.__node_namespace))
             if not self.__expanded_node_namespace.startswith('/'):
-                self.__expanded_node_namespace = '/' + self.__expanded_node_namespace
+                base_ns = context.launch_configurations.get('ros_namespace', '')
+                self.__expanded_node_namespace = base_ns + '/' + self.__expanded_node_namespace
+                if not self.__expanded_node_namespace.startswith('/'):
+                    self.__expanded_node_namespace = '/' + self.__expanded_node_namespace
             validate_namespace(self.__expanded_node_namespace)
         except Exception:
             self.__logger.error(

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -286,7 +286,9 @@ class Node(ExecuteProcess):
                     context, normalize_to_list_of_substitutions(self.__node_namespace))
             if not self.__expanded_node_namespace.startswith('/'):
                 base_ns = context.launch_configurations.get('ros_namespace', '')
-                self.__expanded_node_namespace = (base_ns + '/' + self.__expanded_node_namespace).rstrip('/')
+                self.__expanded_node_namespace = (
+                    base_ns + '/' + self.__expanded_node_namespace
+                ).rstrip('/')
                 if not self.__expanded_node_namespace.startswith('/'):
                     self.__expanded_node_namespace = '/' + self.__expanded_node_namespace
             validate_namespace(self.__expanded_node_namespace)

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -286,7 +286,7 @@ class Node(ExecuteProcess):
                     context, normalize_to_list_of_substitutions(self.__node_namespace))
             if not self.__expanded_node_namespace.startswith('/'):
                 base_ns = context.launch_configurations.get('ros_namespace', '')
-                self.__expanded_node_namespace = base_ns + '/' + self.__expanded_node_namespace
+                self.__expanded_node_namespace = (base_ns + '/' + self.__expanded_node_namespace).rstrip('/')
                 if not self.__expanded_node_namespace.startswith('/'):
                     self.__expanded_node_namespace = '/' + self.__expanded_node_namespace
             validate_namespace(self.__expanded_node_namespace)
@@ -353,3 +353,8 @@ class Node(ExecuteProcess):
                 ros_specific_arguments.append('{}:={}'.format(remapping_from, remapping_to))
         context.extend_locals({'ros_specific_arguments': ros_specific_arguments})
         return super().execute(context)
+
+    @property
+    def expanded_node_namespace(self):
+        """Getter for expanded_node_namespace."""
+        return self.__expanded_node_namespace

--- a/launch_ros/launch_ros/actions/push_ros_namespace.py
+++ b/launch_ros/launch_ros/actions/push_ros_namespace.py
@@ -1,0 +1,64 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the `PushRosNamespace` action."""
+
+from typing import List
+
+from launch import Substitution
+from launch.actions import Action
+from launch.frontend import Entity
+from launch.frontend import Parser
+from launch.launch_context import LaunchContext
+from launch.some_substitutions_type import SomeSubstitutionsType
+from launch.utilities import normalize_to_list_of_substitutions
+from launch.utilities import perform_substitutions
+
+
+class PushRosNamespace(Action):
+    """
+    Action that pushes the ros namespace.
+
+    It's automatically popped when used inside a scoped `GroupAction`.
+    There's not other way of popping it.
+    """
+
+    def __init__(
+        self,
+        namespace: SomeSubstitutionsType,
+        **kwargs
+    ) -> None:
+        """Constructor."""
+        super().__init__(**kwargs)
+        self.__namespace = normalize_to_list_of_substitutions(namespace)
+
+    @classmethod
+    def parse(cls, entity: Entity, parser: Parser):
+        """Return `SetLaunchConfiguration` action and kwargs for constructing it."""
+        _, kwargs = super().parse(entity, parser)
+        kwargs['namespace'] = parser.parse_substitution(entity.get_attr('namespace'))
+        return cls, kwargs
+
+    @property
+    def namespace(self) -> List[Substitution]:
+        """Getter for self.__name."""
+        return self.__namespace
+
+    def execute(self, context: LaunchContext):
+        """Execute the action."""
+        namespace = perform_substitutions(context, self.namespace).rstrip('/')
+        if not namespace.startswith('/'):
+            namespace = context.launch_configurations.get('ros_namespace', '') \
+                + '/' + namespace
+        context.launch_configurations['ros_namespace'] = namespace

--- a/launch_ros/launch_ros/actions/push_ros_namespace.py
+++ b/launch_ros/launch_ros/actions/push_ros_namespace.py
@@ -16,8 +16,8 @@
 
 from typing import List
 
+from launch import Action
 from launch import Substitution
-from launch.actions import Action
 from launch.frontend import Entity
 from launch.frontend import Parser
 from launch.launch_context import LaunchContext
@@ -57,8 +57,8 @@ class PushRosNamespace(Action):
 
     def execute(self, context: LaunchContext):
         """Execute the action."""
-        namespace = perform_substitutions(context, self.namespace).rstrip('/')
+        namespace = perform_substitutions(context, self.namespace)
         if not namespace.startswith('/'):
             namespace = context.launch_configurations.get('ros_namespace', '') \
                 + '/' + namespace
-        context.launch_configurations['ros_namespace'] = namespace
+        context.launch_configurations['ros_namespace'] = namespace.rstrip('/')

--- a/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
@@ -1,0 +1,78 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the PushRosNamespace Action."""
+
+from launch import LaunchContext
+
+from launch_ros.actions import Node
+from launch_ros.actions import PushRosNamespace
+
+import pytest
+
+
+class Config:
+
+    def __init__(
+        self,
+        *,
+        push_ns,
+        node_ns,
+        expected_ns,
+        second_push_ns=None
+    ):
+        self.push_ns = push_ns
+        self.node_ns = node_ns
+        self.expected_ns = expected_ns
+        self.second_push_ns = second_push_ns
+
+
+@pytest.mark.parametrize('config', (
+    Config(
+        push_ns='relative_ns',
+        node_ns='node_ns',
+        expected_ns='/relative_ns/node_ns'),
+    Config(
+        push_ns='relative_ns',
+        node_ns='/node_ns',
+        expected_ns='/node_ns'),
+    Config(
+        push_ns='relative_ns',
+        node_ns=None,
+        expected_ns='/relative_ns'),
+    Config(
+        push_ns='relative_ns',
+        second_push_ns='another_relative_ns',
+        node_ns='node_ns',
+        expected_ns='/relative_ns/another_relative_ns/node_ns'),
+    Config(
+        push_ns='relative_ns',
+        second_push_ns='/absolute_ns',
+        node_ns='node_ns',
+        expected_ns='/absolute_ns/node_ns'),
+))
+def test_push_ros_namespace(config):
+    lc = LaunchContext()
+    pns1 = PushRosNamespace(config.push_ns)
+    pns1.execute(lc)
+    if config.second_push_ns is not None:
+        pns2 = PushRosNamespace(config.second_push_ns)
+        pns2.execute(lc)
+    node = Node(
+        package='dont_care',
+        node_executable='whatever',
+        node_namespace=config.node_ns,
+    )
+    node._perform_substitutions(lc)
+    assert node.expanded_node_namespace == config.expected_ns


### PR DESCRIPTION
Based on discussion https://github.com/ros2/design/pull/207#pullrequestreview-260917648, https://github.com/ros2/design/pull/207#issuecomment-510995374, and inspired on `Node` action [documentation](https://github.com/ros2/launch_ros/blob/5fac112b739a2c63222e3267a179a19fdfa6eef1/launch_ros/launch_ros/actions/node.py#L90-L97) (of a feature that was documented but not implemented).

This adds a way of scoping ROS entities in a namespace.

Example usage:
```python3
LaunchDescription([
    GroupAction([
        PushRosNamespace('my_ns'),
        IncludeLaunchDescription(PythonLaunchDescriptionSource('another_launch_file'),
    ])
])
```

I think we should consider in the future:
- Add `GroupAction` and `IncludeLaunchDescription` alternatives in `launch_ros`. Add to them an extra `ros_namespace` argument.
- Add `scoped` argument to `IncludeLaunchDescription` action (in `launch`), default to `True` (which will break api, but I think is more "normal").