### PR TITLE
Fix PushRosNamespace action

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -59,7 +59,7 @@ class Node(ExecuteProcess):
         package: SomeSubstitutionsType,
         node_executable: SomeSubstitutionsType,
         node_name: Optional[SomeSubstitutionsType] = None,
-        node_namespace: Optional[SomeSubstitutionsType] = '',
+        node_namespace: SomeSubstitutionsType = '',
         parameters: Optional[SomeParameters] = None,
         remappings: Optional[SomeRemapRules] = None,
         arguments: Optional[Iterable[SomeSubstitutionsType]] = None,
@@ -131,10 +131,9 @@ class Node(ExecuteProcess):
             cmd += [LocalSubstitution(
                 'ros_specific_arguments[{}]'.format(ros_args_index), description='node name')]
             ros_args_index += 1
-        if node_namespace is not None:
-            cmd += [LocalSubstitution(
-                'ros_specific_arguments[{}]'.format(ros_args_index), description='node namespace')]
-            ros_args_index += 1
+        cmd += [LocalSubstitution(
+            'ros_specific_arguments[{}]'.format(ros_args_index), description='node namespace')]
+        ros_args_index += 1
         if parameters is not None:
             ensure_argument_type(parameters, (list), 'parameters', 'Node')
             # All elements in the list are paths to files with parameters (or substitutions that
@@ -281,18 +280,15 @@ class Node(ExecuteProcess):
                     context, normalize_to_list_of_substitutions(self.__node_name))
                 validate_node_name(self.__expanded_node_name)
             self.__expanded_node_name.lstrip('/')
-            if self.__node_namespace is not None:
-                self.__expanded_node_namespace = perform_substitutions(
-                    context, normalize_to_list_of_substitutions(self.__node_namespace))
+            self.__expanded_node_namespace = perform_substitutions(
+                context, normalize_to_list_of_substitutions(self.__node_namespace))
+            if not self.__expanded_node_namespace.startswith('/'):
+                base_ns = context.launch_configurations.get('ros_namespace', '')
+                self.__expanded_node_namespace = (
+                    base_ns + '/' + self.__expanded_node_namespace
+                ).rstrip('/')
                 if not self.__expanded_node_namespace.startswith('/'):
-                    base_ns = context.launch_configurations.get('ros_namespace', '')
-                    self.__expanded_node_namespace = (
-                        base_ns + '/' + self.__expanded_node_namespace
-                    ).rstrip('/')
-                    if not self.__expanded_node_namespace.startswith('/'):
-                        self.__expanded_node_namespace = '/' + self.__expanded_node_namespace
-            else:
-                self.__expanded_node_namespace = '/'
+                    self.__expanded_node_namespace = '/' + self.__expanded_node_namespace
             validate_namespace(self.__expanded_node_namespace)
         except Exception:
             self.__logger.error(
@@ -347,8 +343,7 @@ class Node(ExecuteProcess):
         ros_specific_arguments = []  # type: List[Text]
         if self.__node_name is not None:
             ros_specific_arguments.append('__node:={}'.format(self.__expanded_node_name))
-        if self.__node_namespace is not None:
-            ros_specific_arguments.append('__ns:={}'.format(self.__expanded_node_namespace))
+        ros_specific_arguments.append('__ns:={}'.format(self.__expanded_node_namespace))
         if self.__expanded_parameter_files is not None:
             for param_file_path in self.__expanded_parameter_files:
                 ros_specific_arguments.append('__params:={}'.format(param_file_path))

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -59,7 +59,7 @@ class Node(ExecuteProcess):
         package: SomeSubstitutionsType,
         node_executable: SomeSubstitutionsType,
         node_name: Optional[SomeSubstitutionsType] = None,
-        node_namespace: Optional[SomeSubstitutionsType] = None,
+        node_namespace: Optional[SomeSubstitutionsType] = '',
         parameters: Optional[SomeParameters] = None,
         remappings: Optional[SomeRemapRules] = None,
         arguments: Optional[Iterable[SomeSubstitutionsType]] = None,
@@ -284,13 +284,15 @@ class Node(ExecuteProcess):
             if self.__node_namespace is not None:
                 self.__expanded_node_namespace = perform_substitutions(
                     context, normalize_to_list_of_substitutions(self.__node_namespace))
-            if not self.__expanded_node_namespace.startswith('/'):
-                base_ns = context.launch_configurations.get('ros_namespace', '')
-                self.__expanded_node_namespace = (
-                    base_ns + '/' + self.__expanded_node_namespace
-                ).rstrip('/')
                 if not self.__expanded_node_namespace.startswith('/'):
-                    self.__expanded_node_namespace = '/' + self.__expanded_node_namespace
+                    base_ns = context.launch_configurations.get('ros_namespace', '')
+                    self.__expanded_node_namespace = (
+                        base_ns + '/' + self.__expanded_node_namespace
+                    ).rstrip('/')
+                    if not self.__expanded_node_namespace.startswith('/'):
+                        self.__expanded_node_namespace = '/' + self.__expanded_node_namespace
+            else:
+                self.__expanded_node_namespace = '/'
             validate_namespace(self.__expanded_node_namespace)
         except Exception:
             self.__logger.error(

--- a/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
@@ -30,49 +30,41 @@ class Config:
         push_ns,
         node_ns,
         expected_ns,
-        second_push_ns=None,
-        ns_in_command
+        second_push_ns=None
     ):
         self.push_ns = push_ns
         self.node_ns = node_ns
         self.expected_ns = expected_ns
         self.second_push_ns = second_push_ns
-        self.ns_in_command = ns_in_command
 
 
 @pytest.mark.parametrize('config', (
     Config(
         push_ns='relative_ns',
         node_ns='node_ns',
-        expected_ns='/relative_ns/node_ns',
-        ns_in_command=True),
+        expected_ns='/relative_ns/node_ns'),
     Config(
         push_ns='relative_ns',
         node_ns='/node_ns',
-        expected_ns='/node_ns',
-        ns_in_command=True),
+        expected_ns='/node_ns'),
     Config(
         push_ns='relative_ns',
-        node_ns=None,
-        expected_ns='/',
-        ns_in_command=False),
+        node_ns='/',
+        expected_ns='/'),
     Config(
         push_ns='relative_ns',
         node_ns='',
-        expected_ns='/relative_ns',
-        ns_in_command=True),
+        expected_ns='/relative_ns'),
     Config(
         push_ns='relative_ns',
         second_push_ns='another_relative_ns',
         node_ns='node_ns',
-        expected_ns='/relative_ns/another_relative_ns/node_ns',
-        ns_in_command=True),
+        expected_ns='/relative_ns/another_relative_ns/node_ns'),
     Config(
         push_ns='relative_ns',
         second_push_ns='/absolute_ns',
         node_ns='node_ns',
-        expected_ns='/absolute_ns/node_ns',
-        ns_in_command=True),
+        expected_ns='/absolute_ns/node_ns'),
 ))
 def test_push_ros_namespace(config):
     lc = LaunchContext()
@@ -88,5 +80,4 @@ def test_push_ros_namespace(config):
     )
     node._perform_substitutions(lc)
     assert node.expanded_node_namespace == config.expected_ns
-    expected_cmd_len = 2 if config.ns_in_command else 1
-    assert expected_cmd_len == len(node.cmd)
+    assert 2 == len(node.cmd)

--- a/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
@@ -30,37 +30,49 @@ class Config:
         push_ns,
         node_ns,
         expected_ns,
-        second_push_ns=None
+        second_push_ns=None,
+        ns_in_command
     ):
         self.push_ns = push_ns
         self.node_ns = node_ns
         self.expected_ns = expected_ns
         self.second_push_ns = second_push_ns
+        self.ns_in_command = ns_in_command
 
 
 @pytest.mark.parametrize('config', (
     Config(
         push_ns='relative_ns',
         node_ns='node_ns',
-        expected_ns='/relative_ns/node_ns'),
+        expected_ns='/relative_ns/node_ns',
+        ns_in_command=True),
     Config(
         push_ns='relative_ns',
         node_ns='/node_ns',
-        expected_ns='/node_ns'),
+        expected_ns='/node_ns',
+        ns_in_command=True),
     Config(
         push_ns='relative_ns',
         node_ns=None,
-        expected_ns='/relative_ns'),
+        expected_ns='/',
+        ns_in_command=False),
+    Config(
+        push_ns='relative_ns',
+        node_ns='',
+        expected_ns='/relative_ns',
+        ns_in_command=True),
     Config(
         push_ns='relative_ns',
         second_push_ns='another_relative_ns',
         node_ns='node_ns',
-        expected_ns='/relative_ns/another_relative_ns/node_ns'),
+        expected_ns='/relative_ns/another_relative_ns/node_ns',
+        ns_in_command=True),
     Config(
         push_ns='relative_ns',
         second_push_ns='/absolute_ns',
         node_ns='node_ns',
-        expected_ns='/absolute_ns/node_ns'),
+        expected_ns='/absolute_ns/node_ns',
+        ns_in_command=True),
 ))
 def test_push_ros_namespace(config):
     lc = LaunchContext()
@@ -76,3 +88,5 @@ def test_push_ros_namespace(config):
     )
     node._perform_substitutions(lc)
     assert node.expanded_node_namespace == config.expected_ns
+    expected_cmd_len = 2 if config.ns_in_command else 1
+    assert expected_cmd_len == len(node.cmd)


### PR DESCRIPTION
Fixes #43.

Though the namespace is expanded correctly, it isn't added to the command when `node_namespace` argument is `None`:
https://github.com/ros2/launch_ros/blob/68337f836b9dfbf4bed2b9c3b3ae03d21570cf13/launch_ros/launch_ros/actions/node.py#L134-L137

I considered two possible fixes:
- Always add the namespace to the command.
- Change `node_namespace` default to `''`. When doing `node_namespace=None`, `__node:={}` argument won't be passed. If a relative namespace is passed, `ros_namespace` launch config will be used.
For absolute namespaces, `ros_namespace` will be ignored.

The second one is a little more flexible, so I applied that one.