### PR TITLE
[launch frontend] Rename some tag attributes

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -237,7 +237,7 @@ class Node(ExecuteProcess):
         kwargs['node_name'] = kwargs['name']
         del kwargs['name']
         kwargs['package'] = parser.parse_substitution(entity.get_attr('pkg'))
-        kwargs['node_executable'] = parser.parse_substitution(entity.get_attr('executable'))
+        kwargs['node_executable'] = parser.parse_substitution(entity.get_attr('exec'))
         ns = entity.get_attr('namespace', optional=True)
         if ns is not None:
             kwargs['node_namespace'] = parser.parse_substitution(ns)

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -236,7 +236,7 @@ class Node(ExecuteProcess):
         del kwargs['args']
         kwargs['node_name'] = kwargs['name']
         del kwargs['name']
-        kwargs['package'] = parser.parse_substitution(entity.get_attr('package'))
+        kwargs['package'] = parser.parse_substitution(entity.get_attr('pkg'))
         kwargs['node_executable'] = parser.parse_substitution(entity.get_attr('executable'))
         ns = entity.get_attr('namespace', optional=True)
         if ns is not None:

--- a/launch_ros/launch_ros/substitutions/executable_in_package.py
+++ b/launch_ros/launch_ros/substitutions/executable_in_package.py
@@ -32,7 +32,7 @@ from osrf_pycommon.process_utils import which
 from .find_package import FindPackage
 
 
-@expose_substitution('exec-in-package')
+@expose_substitution('exec-in-pkg')
 class ExecutableInPackage(FindPackage):
     """
     Substitution that tries to locate an executable in the libexec directory of a ROS package.

--- a/launch_ros/launch_ros/substitutions/find_package.py
+++ b/launch_ros/launch_ros/substitutions/find_package.py
@@ -28,7 +28,7 @@ from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
 
 
-@expose_substitution('find-package')
+@expose_substitution('find-pkg')
 class FindPackage(Substitution):
     """
     Substitution that tries to locate the package prefix of a ROS package.

--- a/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
@@ -31,7 +31,7 @@ xml_file = \
     <launch>
         <let name="a_string" value="\'[2, 5, 8]\'"/>
         <let name="a_list" value="[2, 5, 8]"/>
-        <node package="demo_nodes_py" executable="talker_qos" output="screen" name="my_node" namespace="my_ns" args="--number_of_cycles 1">
+        <node pkg="demo_nodes_py" exec="talker_qos" output="screen" name="my_node" namespace="my_ns" args="--number_of_cycles 1">
             <param name="param1" value="ads"/>
             <param name="param_group1">
                 <param name="param_group2">
@@ -63,8 +63,8 @@ yaml_file = \
             name: 'a_list'
             value: '[2, 5, 8]'
         - node:
-            package: demo_nodes_py
-            executable: talker_qos
+            pkg: demo_nodes_py
+            exec: talker_qos
             output: screen
             name: my_node
             namespace: my_ns


### PR DESCRIPTION
As commented in https://github.com/ros2/ros2_documentation/pull/302, I did a minimal renaming.
A little less verbose, and it matches better with ROS 1.

Changes summary:
package -> pkg
executable -> exec

P.S.: Didn't change `executable` tag name. I think it's fine.