### PR TITLE
Use node namespace if no other was specified

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -17,11 +17,14 @@
 import os
 import pathlib
 from tempfile import NamedTemporaryFile
+from typing import cast
+from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Text  # noqa: F401
 from typing import Tuple  # noqa: F401
+from typing import Union
 
 from launch.action import Action
 from launch.actions import ExecuteProcess
@@ -340,19 +343,21 @@ class Node(ExecuteProcess):
         self._perform_substitutions(context)
         # Prepare the ros_specific_arguments list and add it to the context so that the
         # LocalSubstitution placeholders added to the the cmd can be expanded using the contents.
-        ros_specific_arguments = {}
+        ros_specific_arguments: Dict[str, Union[str, List[str]]] = {}
         if self.__node_name is not None:
             ros_specific_arguments['name'] = '__node:={}'.format(self.__expanded_node_name)
         if self.__expanded_node_namespace != '':
             ros_specific_arguments['ns'] = '__ns:={}'.format(self.__expanded_node_namespace)
         if self.__expanded_parameter_files is not None:
             ros_specific_arguments['params'] = []
+            param_arguments = cast(List[str], ros_specific_arguments['params'])
             for param_file_path in self.__expanded_parameter_files:
-                ros_specific_arguments['params'].append('__params:={}'.format(param_file_path))
+                param_arguments.append('__params:={}'.format(param_file_path))
         if self.__expanded_remappings is not None:
             ros_specific_arguments['remaps'] = []
             for remapping_from, remapping_to in self.__expanded_remappings:
-                ros_specific_arguments['remaps'].append(
+                remap_arguments = cast(List[str], ros_specific_arguments['remaps'])
+                remap_arguments.append(
                     '{}:={}'.format(remapping_from, remapping_to)
                 )
         context.extend_locals({'ros_specific_arguments': ros_specific_arguments})

--- a/launch_ros/launch_ros/actions/push_ros_namespace.py
+++ b/launch_ros/launch_ros/actions/push_ros_namespace.py
@@ -21,8 +21,8 @@ from launch import Substitution
 from launch.frontend import Entity
 from launch.frontend import Parser
 from launch.launch_context import LaunchContext
-from launch.substitutions import SubstitutionFailure
 from launch.some_substitutions_type import SomeSubstitutionsType
+from launch.substitutions import SubstitutionFailure
 from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
 

--- a/launch_ros/launch_ros/actions/push_ros_namespace.py
+++ b/launch_ros/launch_ros/actions/push_ros_namespace.py
@@ -25,6 +25,8 @@ from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
 
+from rclpy.validate_namespace import validate_namespace
+
 
 class PushRosNamespace(Action):
     """
@@ -61,4 +63,6 @@ class PushRosNamespace(Action):
         if not namespace.startswith('/'):
             namespace = context.launch_configurations.get('ros_namespace', '') \
                 + '/' + namespace
-        context.launch_configurations['ros_namespace'] = namespace.rstrip('/')
+        namespace = namespace.rstrip('/')
+        validate_namespace(namespace)
+        context.launch_configurations['ros_namespace'] = namespace

--- a/launch_ros/launch_ros/actions/push_ros_namespace.py
+++ b/launch_ros/launch_ros/actions/push_ros_namespace.py
@@ -66,13 +66,14 @@ class PushRosNamespace(Action):
         if not pushed_namespace.startswith('/'):
             namespace = previous_namespace + '/' + pushed_namespace
         namespace = namespace.rstrip('/')
-        try:
-            validate_namespace(namespace)
-        except Exception:
-            raise SubstitutionFailure(
-                'The resulting namespace is invalid:'
-                " [previous_namespace='{}', pushed_namespace='{}']".format(
-                    previous_namespace, pushed_namespace
+        if namespace != '':
+            try:
+                validate_namespace(namespace)
+            except Exception:
+                raise SubstitutionFailure(
+                    'The resulting namespace is invalid:'
+                    " [previous_namespace='{}', pushed_namespace='{}']".format(
+                        previous_namespace, pushed_namespace
+                    )
                 )
-            )
         context.launch_configurations['ros_namespace'] = namespace

--- a/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
@@ -27,9 +27,9 @@ class Config:
     def __init__(
         self,
         *,
-        push_ns,
-        node_ns,
-        expected_ns,
+        node_ns='',
+        push_ns=None,
+        expected_ns=None,
         second_push_ns=None
     ):
         self.push_ns = push_ns
@@ -65,11 +65,14 @@ class Config:
         second_push_ns='/absolute_ns',
         node_ns='node_ns',
         expected_ns='/absolute_ns/node_ns'),
+    Config(),
+    Config(push_ns=''),
 ))
 def test_push_ros_namespace(config):
     lc = LaunchContext()
-    pns1 = PushRosNamespace(config.push_ns)
-    pns1.execute(lc)
+    if config.push_ns is not None:
+        pns1 = PushRosNamespace(config.push_ns)
+        pns1.execute(lc)
     if config.second_push_ns is not None:
         pns2 = PushRosNamespace(config.second_push_ns)
         pns2.execute(lc)
@@ -79,5 +82,7 @@ def test_push_ros_namespace(config):
         node_namespace=config.node_ns,
     )
     node._perform_substitutions(lc)
-    assert node.expanded_node_namespace == config.expected_ns
-    assert 2 == len(node.cmd)
+    expected_cmd_len = 2 if config.expected_ns is not None else 1
+    assert expected_cmd_len == len(node.cmd)
+    expected_ns = config.expected_ns if config.expected_ns is not None else ''
+    assert expected_ns == node.expanded_node_namespace

--- a/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
@@ -66,7 +66,6 @@ class Config:
         node_ns='node_ns',
         expected_ns='/absolute_ns/node_ns'),
     Config(),
-    Config(push_ns=''),
 ))
 def test_push_ros_namespace(config):
     lc = LaunchContext()

--- a/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
@@ -66,6 +66,7 @@ class Config:
         node_ns='node_ns',
         expected_ns='/absolute_ns/node_ns'),
     Config(),
+    Config(push_ns=''),
 ))
 def test_push_ros_namespace(config):
     lc = LaunchContext()


### PR DESCRIPTION
If no namespace is pushed (by `PushRosNamespace`), and the user doesn't use `node_namespace` argument of `Node` action, the default namespace specified by the node should be used.

I forgot about that, and in that case `__ns:=/` was being added to the command (which is wrong).
I'm doing the corrections to avoid that.

----

(Edit) I finally didn't allow this

(Original)

If someone uses `PushRosNamespace('')`, and the `node_namespace` argument of `Node` action is the default (`''`), the namespace indicated by the node is used.

I thought it could by helpful for this case:
```python3
LaunchDescription([
    ...,
    PushRosNamespace(LaunchConfiguration(variable_name='namespace', default=''),
    Node(...),
    ...,
])
```
In that case, if the variable name doesn't exist, the namespace specified by the node will be used (and there is no need of copying it again in the launch file).

The other option is to raise an error when someone pass `''` to `PushRosNamespace`.