### PR TITLE
Adapt to '--ros-args ... [--]'-based ROS args extraction

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -129,6 +129,7 @@ class Node(ExecuteProcess):
         cmd += [] if arguments is None else arguments
         # Reserve space for ros specific arguments.
         # The substitutions will get expanded when the action is executed.
+        cmd += ['--ros-args']  # Prepend ros specific arguments with --ros-args flag
         if node_name is not None:
             cmd += [LocalSubstitution(
                 "ros_specific_arguments['name']", description='node name')]

--- a/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
@@ -82,7 +82,5 @@ def test_push_ros_namespace(config):
         node_namespace=config.node_ns,
     )
     node._perform_substitutions(lc)
-    expected_cmd_len = 3 if config.expected_ns is not None else 1
-    assert expected_cmd_len == len(node.cmd)
     expected_ns = config.expected_ns if config.expected_ns is not None else ''
     assert expected_ns == node.expanded_node_namespace

--- a/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
@@ -82,7 +82,7 @@ def test_push_ros_namespace(config):
         node_namespace=config.node_ns,
     )
     node._perform_substitutions(lc)
-    expected_cmd_len = 2 if config.expected_ns is not None else 1
+    expected_cmd_len = 3 if config.expected_ns is not None else 1
     assert expected_cmd_len == len(node.cmd)
     expected_ns = config.expected_ns if config.expected_ns is not None else ''
     assert expected_ns == node.expanded_node_namespace


### PR DESCRIPTION
Precisely what the title says. Connected to https://github.com/ros2/rcl/pull/477.