### PR TITLE
Add substitution for finding package share directory

### DIFF
--- a/launch_ros/launch_ros/substitutions/__init__.py
+++ b/launch_ros/launch_ros/substitutions/__init__.py
@@ -16,11 +16,13 @@
 
 from .executable_in_package import ExecutableInPackage
 from .find_package import FindPackage
+from .find_package import FindPackagePrefix
 from .find_package import FindPackageShare
 
 
 __all__ = [
     'ExecutableInPackage',
     'FindPackage',
+    'FindPackagePrefix',
     'FindPackageShare',
 ]

--- a/launch_ros/launch_ros/substitutions/__init__.py
+++ b/launch_ros/launch_ros/substitutions/__init__.py
@@ -16,9 +16,11 @@
 
 from .executable_in_package import ExecutableInPackage
 from .find_package import FindPackage
+from .find_package import FindPackageShare
 
 
 __all__ = [
     'ExecutableInPackage',
     'FindPackage',
+    'FindPackageShare',
 ]

--- a/launch_ros/launch_ros/substitutions/executable_in_package.py
+++ b/launch_ros/launch_ros/substitutions/executable_in_package.py
@@ -29,11 +29,11 @@ from launch.utilities import perform_substitutions
 
 from osrf_pycommon.process_utils import which
 
-from .find_package import FindPackage
+from .find_package import FindPackagePrefix
 
 
 @expose_substitution('exec-in-pkg')
-class ExecutableInPackage(FindPackage):
+class ExecutableInPackage(FindPackagePrefix):
     """
     Substitution that tries to locate an executable in the libexec directory of a ROS package.
 

--- a/launch_ros/launch_ros/substitutions/find_package.py
+++ b/launch_ros/launch_ros/substitutions/find_package.py
@@ -51,7 +51,7 @@ class FindPackage(Substitution):
     def parse(cls, data: Iterable[SomeSubstitutionsType]):
         """Parse a FindPackage substitution."""
         if not data or len(data) != 1:
-            raise AttributeError('find-package substitution expects 1 argument')
+            raise AttributeError('find package substitutions expect 1 argument')
         kwargs = {'package': data[0]}
         return cls, kwargs
 
@@ -74,7 +74,7 @@ class FindPackage(Substitution):
     def describe(self) -> Text:
         """Return a description of this substitution as a string."""
         pkg_str = ' + '.join([sub.describe() for sub in self.package])
-        return 'Pkg(pkg={})'.format(pkg_str)
+        return '{}(pkg={})'.format(self.__class__.__name__, pkg_str)
 
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution by locating the package."""

--- a/launch_ros/launch_ros/substitutions/find_package.py
+++ b/launch_ros/launch_ros/substitutions/find_package.py
@@ -14,7 +14,6 @@
 
 """Module for the FindPackage substitution."""
 
-from typing import Callable
 from typing import Iterable
 from typing import List
 from typing import Text
@@ -40,12 +39,10 @@ class FindPackage(Substitution):
     def __init__(
         self,
         package: SomeSubstitutionsType,
-        find_package_func: Callable[[str], str] = get_package_prefix
     ) -> None:
         """Constructor."""
         super().__init__()
         self.__package = normalize_to_list_of_substitutions(package)
-        self.__find_package_func = find_package_func
 
     @classmethod
     def parse(cls, data: Iterable[SomeSubstitutionsType]):
@@ -104,7 +101,7 @@ class FindPackageShare(FindPackage):
     """
     Substitution that tries to locate the share directory of a ROS package.
 
-    The directory located using ament_index_python.
+    The directory is located using ament_index_python.
 
     :raise: ament_index_python.packages.PackageNotFoundError when package is
         not found during substitution.

--- a/launch_ros/launch_ros/substitutions/find_package.py
+++ b/launch_ros/launch_ros/substitutions/find_package.py
@@ -30,7 +30,7 @@ from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
 
 
-@expose_substitution('find-pkg-root')
+@expose_substitution('find-pkg-prefix')
 class FindPackage(Substitution):
     """
     Substitution that tries to locate the package prefix of a ROS package.
@@ -77,7 +77,7 @@ class FindPackage(Substitution):
         return result
 
 
-@expose_substitution('find-pkg')
+@expose_substitution('find-pkg-share')
 class FindPackageShare(FindPackage):
     """
     Substitution that tries to locate the share directory of a ROS package.

--- a/test_launch_ros/test/test_launch_ros/substitutions/test_find_package.py
+++ b/test_launch_ros/test/test_launch_ros/substitutions/test_find_package.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test for the FindPackage substitution."""
+"""Test for the FindPackage substitutions."""
 
 from pathlib import Path
 
 from launch import LaunchContext
 
-from launch_ros.substitutions import FindPackage
+from launch_ros.substitutions import FindPackagePrefix
 from launch_ros.substitutions import FindPackageShare
 
 
-def test_find_package():
-    sub = FindPackage('launch_ros')
+def test_find_package_prefix():
+    sub = FindPackagePrefix('launch_ros')
     context = LaunchContext()
     package_prefix = Path(sub.perform(context))
     package_xml_file = package_prefix / Path('share/launch_ros/package.xml')

--- a/test_launch_ros/test/test_launch_ros/substitutions/test_find_package.py
+++ b/test_launch_ros/test/test_launch_ros/substitutions/test_find_package.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from launch import LaunchContext
 
 from launch_ros.substitutions import FindPackage
+from launch_ros.substitutions import FindPackageShare
 
 
 def test_find_package():
@@ -26,4 +27,12 @@ def test_find_package():
     context = LaunchContext()
     package_prefix = Path(sub.perform(context))
     package_xml_file = package_prefix / Path('share/launch_ros/package.xml')
+    assert package_xml_file.is_file()
+
+
+def test_find_package_share():
+    sub = FindPackageShare('launch_ros')
+    context = LaunchContext()
+    package_prefix = Path(sub.perform(context))
+    package_xml_file = package_prefix / Path('package.xml')
     assert package_xml_file.is_file()


### PR DESCRIPTION
Expose FindPackageShare as 'find-pkg' and FindPackage as 'find-pkg-root'.
The rationale is that getting the share directory is the more common use-case (e.g. including launch files).

This turns

    <include file="$(find-pkg foo)/share/foo/launch/foo.launch.xml">

into

    <include file="$(find-pkg foo)/launch/foo.launch.xml">

