### PR TITLE
Only keep base name of parameter name from yaml file

### DIFF
--- a/launch_ros/launch_ros/utilities/normalize_parameters.py
+++ b/launch_ros/launch_ros/utilities/normalize_parameters.py
@@ -143,6 +143,12 @@ def normalize_parameter_dict(
         # Normalize the value next
         if isinstance(value, Mapping):
             # Flatten recursive dictionaries
+            pos = -1
+            for index, text_sub in enumerate(name):
+                if text_sub.text == 'ros__parameters':
+                    pos = index
+            if pos != -1:
+                name = name[pos+1:]
             sub_dict = normalize_parameter_dict(value, _prefix=name)
             normalized.update(sub_dict)
         elif isinstance(value, str):


### PR DESCRIPTION
A full name which includes namespace, node name and the string of "ros__parameters" from yaml file will cause an issue, See https://github.com/ros2/launch_ros/issues/55 for details.

Signed-off-by: Xiaojun <xiaojun.huang@intel.com>