### PR TITLE
[backport-dashing] install package marker and manifest (#62)

### DIFF
--- a/launch_ros/setup.py
+++ b/launch_ros/setup.py
@@ -1,10 +1,17 @@
 from setuptools import find_packages
 from setuptools import setup
 
+package_name = 'launch_ros'
+
 setup(
-    name='launch_ros',
+    name=package_name,
     version='0.8.5',
     packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+    ],
     install_requires=[
         'setuptools',
         'ament_index_python',


### PR DESCRIPTION
Backport of #62 for Dashing.

Should fix this test failure: http://build.ros2.org/view/Dci/job/Dci__nightly-fastrtps_ubuntu_bionic_amd64/112/testReport/junit/test_launch_ros.test.test_launch_ros.substitutions/test_find_package/test_find_package/