### PR TITLE
[Dashing] Restore Python 3.5 support

### DIFF
--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -40,7 +40,7 @@ class LoadComposableNodes(Action):
         *,
         composable_node_descriptions: List[ComposableNode],
         target_container: ComposableNodeContainer,
-        **kwargs,
+        **kwargs
     ) -> None:
         """
         Construct a LoadComposableNodes action.

--- a/launch_ros/launch_ros/descriptions/composable_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_node.py
@@ -40,7 +40,7 @@ class ComposableNode:
         node_namespace: Optional[SomeSubstitutionsType] = None,
         parameters: Optional[SomeParameters] = None,
         remappings: Optional[SomeRemapRules] = None,
-        extra_arguments: Optional[SomeParameters] = None,
+        extra_arguments: Optional[SomeParameters] = None
     ) -> None:
         """
         Initialize a ComposableNode description.

--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -43,7 +43,7 @@ def evaluate_parameter_dict(
 ) -> Dict[str, EvaluatedParameterValue]:
     if not isinstance(parameters, Mapping):
         raise TypeError('expected dict')
-    output_dict: Dict[str, EvaluatedParameterValue] = {}
+    output_dict = {} # type: Dict[str, EvaluatedParameterValue] 
     for name, value in parameters.items():
         if not isinstance(name, tuple):
             raise TypeError('Expecting tuple of substitutions got {}'.format(repr(name)))

--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -43,7 +43,7 @@ def evaluate_parameter_dict(
 ) -> Dict[str, EvaluatedParameterValue]:
     if not isinstance(parameters, Mapping):
         raise TypeError('expected dict')
-    output_dict = {} # type: Dict[str, EvaluatedParameterValue] 
+    output_dict = {}  # type: Dict[str, EvaluatedParameterValue]
     for name, value in parameters.items():
         if not isinstance(name, tuple):
             raise TypeError('Expecting tuple of substitutions got {}'.format(repr(name)))


### PR DESCRIPTION
Removes some trailing commas and converts an unsupported type hint to a
type comment.