### PR TITLE
[Dashing] Additional fixes for Python 3.5.

### DIFF
--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -64,7 +64,7 @@ def evaluate_parameter_dict(
                     evaluated_value = tuple(output_subvalue)
                 # All values in a list must have the same type.
                 # If they don't then assume it is a list of strings
-                yaml_evaluated_value = []  # type: Union[List[str], List[int], List[float], List[bool]]
+                yaml_evaluated_value = []
                 last_subtype = None
                 dissimilar_types = False
                 for subvalue in evaluated_value:

--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -47,8 +47,8 @@ def evaluate_parameter_dict(
     for name, value in parameters.items():
         if not isinstance(name, tuple):
             raise TypeError('Expecting tuple of substitutions got {}'.format(repr(name)))
-        evaluated_name: str = perform_substitutions(context, list(name))
-        evaluated_value: Optional[EvaluatedParameterValue] = None
+        evaluated_name = perform_substitutions(context, list(name))  # type: str
+        evaluated_value = None  # type: Optional[EvaluatedParameterValue]
 
         if isinstance(value, tuple) and len(value):
             if isinstance(value[0], Substitution):
@@ -57,14 +57,14 @@ def evaluate_parameter_dict(
                 evaluated_value = yaml.safe_load(evaluated_value)
             elif isinstance(value[0], Sequence):
                 # Value is an array of a list of substitutions
-                output_subvalue: List[str] = []
+                output_subvalue = []  # type: List[str]
                 for subvalue in value:
                     value = perform_substitutions(context, list(subvalue))
                     output_subvalue.append(value)
                     evaluated_value = tuple(output_subvalue)
                 # All values in a list must have the same type.
                 # If they don't then assume it is a list of strings
-                yaml_evaluated_value: Union[List[str], List[int], List[float], List[bool]] = []
+                yaml_evaluated_value = []  # type: Union[List[str], List[int], List[float], List[bool]]
                 last_subtype = None
                 dissimilar_types = False
                 for subvalue in evaluated_value:

--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -20,8 +20,8 @@ from collections.abc import Sequence
 import pathlib
 from typing import cast
 from typing import Dict
-from typing import List
-from typing import Optional
+from typing import List  # noqa: F401
+from typing import Optional  # noqa: F401
 from typing import Union
 
 from launch.launch_context import LaunchContext


### PR DESCRIPTION
Some Python 3.5 fixes got missed in the last revision.

Using a variant of @sloretz's Dockerfile this PR is now clean against flake8 --select=E999 on Debian Stretch.