### PR TITLE
Do not import rclpy nor launch_ros at module level.

### DIFF
--- a/launch_testing_ros/launch_testing_ros/test_runner.py
+++ b/launch_testing_ros/launch_testing_ros/test_runner.py
@@ -15,20 +15,19 @@
 """Module for a ROS aware LaunchTestRunner."""
 
 import launch
-import launch_ros
 import launch_testing.test_runner
-
-import rclpy
 
 
 class LaunchTestRunner(launch_testing.test_runner.LaunchTestRunner):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        import rclpy  # Import on first use to avoid races at module level
         self._rclpy_context = rclpy.context.Context()
         rclpy.init(args=self._launch_file_arguments, context=self._rclpy_context)
 
     def generate_preamble(self):
+        import launch_ros  # Import on first use to avoid races at module level
         return [launch.actions.IncludeLaunchDescription(
             launch_description_source=launch.LaunchDescriptionSource(
                 launch_description=launch_ros.get_default_launch_description(


### PR DESCRIPTION
Precisely what the title says. It does not solve the root cause of the problem (see https://github.com/ros2/build_cop/issues/235#issuecomment-529537182), but works around it.