### PR TITLE
Handle zero-width string parameters.

### DIFF
--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -67,7 +67,9 @@ def evaluate_parameter_dict(
             if isinstance(value[0], Substitution):
                 # Value is a list of substitutions, so perform them to make a string
                 evaluated_value = perform_substitutions(context, list(value))
-                yaml_evaluated_value = yaml.safe_load(evaluated_value)
+                yaml_evaluated_value = yaml.load(evaluated_value)
+                if yaml_evaluated_value is None:
+                    yaml_evaluated_value = ''
                 if type(yaml_evaluated_value) in (bool, int, float, str, bytes):
                     evaluated_value = yaml_evaluated_value
                 elif isinstance(yaml_evaluated_value, Sequence):

--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -67,7 +67,7 @@ def evaluate_parameter_dict(
             if isinstance(value[0], Substitution):
                 # Value is a list of substitutions, so perform them to make a string
                 evaluated_value = perform_substitutions(context, list(value))
-                yaml_evaluated_value = yaml.load(evaluated_value)
+                yaml_evaluated_value = yaml.safe_load(evaluated_value)
                 if yaml_evaluated_value is None:
                     yaml_evaluated_value = ''
                 if type(yaml_evaluated_value) in (bool, int, float, str, bytes):

--- a/test_launch_ros/test/test_launch_ros/actions/example_parameters.yaml
+++ b/test_launch_ros/test/test_launch_ros/actions/example_parameters.yaml
@@ -3,6 +3,7 @@
         ros__parameters:
             some_int: 42
             a_string: "Hello world"
+            no_string: ""
             some_list:
                 sub_list:
                     some_integers: [1, 2, 3, 4]

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -151,7 +151,8 @@ class TestNode(unittest.TestCase):
                     'param_group2': {
                         (EnvironmentVariable('PARAM2'), '_values'): ['param2_value'],
                     }
-                }
+                },
+                'param3': ''
             }],
         )
         self._assert_launch_no_errors([node_action])
@@ -166,6 +167,7 @@ class TestNode(unittest.TestCase):
                     'ros__parameters': {
                         'param1': 'param1_value',
                         'param2': 'param2_value',
+                        'param3': '',
                         'param_group1.list_params': (1.2, 3.4),
                         'param_group1.param_group2.param2_values': ('param2_value',),
                     }

--- a/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
@@ -46,6 +46,7 @@ xml_file = \
                 <param name="param9" value="\'2\', \'5\', \'8\'" value-sep=", "/>
                 <param name="param10" value="''asd'', ''bsd'', ''csd''" value-sep=", "/>
                 <param name="param11" value="'\asd', '\bsd', '\csd'" value-sep=", "/>
+                <param name="param12" value=""/>
             </param>
             <param from="{}"/>
             <env name="var" value="1"/>
@@ -96,6 +97,8 @@ yaml_file = \
                         value: ["'asd'", "'bsd'", "'csd'"]
                     -   name: param11
                         value: ['\asd', '\bsd', '\csd']
+                    -   name: param12
+                        value: ''
                 -   from: {}
             env:
                 -   name: var
@@ -141,3 +144,4 @@ def test_node_frontend(file):
     assert param_dict['param_group1.param9'] == ("'2'", "'5'", "'8'")
     assert param_dict['param_group1.param10'] == ("'asd'", "'bsd'", "'csd'")
     assert param_dict['param_group1.param11'] == ('asd', 'bsd', 'csd')
+    assert param_dict['param_group1.param12'] == ''


### PR DESCRIPTION
Precisely what the title says. Loading an empty string results in `None` when using the `yaml` module. 

Additional integration tests for zero-width parameters are added.