### PR TITLE
Allow separate launch composition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ __pycache__
 .mypy_cache
 .pytest_cache
 .flake8
-.vscode
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 .mypy_cache
 .pytest_cache
 .flake8
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ __pycache__
 .mypy_cache
 .pytest_cache
 .flake8
-

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -26,10 +26,10 @@ from launch.launch_context import LaunchContext
 import launch.logging
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.some_substitutions_type import SomeSubstitutionsType_types_tuple
-from launch.utilities import normalize_to_list_of_substitutions
-from launch.utilities import perform_substitutions
 from launch.utilities import ensure_argument_type
 from launch.utilities import is_a_subclass
+from launch.utilities import normalize_to_list_of_substitutions
+from launch.utilities import perform_substitutions
 
 from .composable_node_container import ComposableNodeContainer
 
@@ -63,7 +63,8 @@ class LoadComposableNodes(Action):
         """
         ensure_argument_type(
             target_container,
-            list(SomeSubstitutionsType_types_tuple) + [ComposableNodeContainer],
+            list(SomeSubstitutionsType_types_tuple) +
+            [ComposableNodeContainer],
             'target_container',
             'LoadComposableNodes'
         )
@@ -174,9 +175,11 @@ class LoadComposableNodes(Action):
             self.__final_target_container_name = self.__target_container.node_name
         elif isinstance(self.__target_container, SomeSubstitutionsType_types_tuple):
             subs = normalize_to_list_of_substitutions(self.__target_container)
-            self.__final_target_container_name = perform_substitutions(context, subs)
+            self.__final_target_container_name = perform_substitutions(
+                context, subs)
         else:
-            self.__logger.error('target container is neither a ComposableNodeContainer nor a SubstitutionType')
+            self.__logger.error(
+                'target container is neither a ComposableNodeContainer nor a SubstitutionType')
             return
 
         # Create a client to load nodes in the target container.

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -39,11 +39,11 @@ class LoadComposableNodes(Action):
     """Action that loads composable ROS nodes into a running container."""
 
     def __init__(
-            self,
-            *,
-            composable_node_descriptions: List[ComposableNode],
-            target_container: Union[SomeSubstitutionsType, ComposableNodeContainer],
-            **kwargs,
+        self,
+        *,
+        composable_node_descriptions: List[ComposableNode],
+        target_container: Union[SomeSubstitutionsType, ComposableNodeContainer],
+        **kwargs,
     ) -> None:
         """
         Construct a LoadComposableNodes action.
@@ -65,9 +65,9 @@ class LoadComposableNodes(Action):
         self.__logger = launch.logging.get_logger(__name__)
 
     def _load_node(
-            self,
-            composable_node_description: ComposableNode,
-            context: LaunchContext
+        self,
+        composable_node_description: ComposableNode,
+        context: LaunchContext
     ) -> None:
         """
         Load node synchronously.
@@ -134,9 +134,9 @@ class LoadComposableNodes(Action):
         ))
 
     def _load_in_sequence(
-            self,
-            composable_node_descriptions: List[ComposableNode],
-            context: LaunchContext
+        self,
+        composable_node_descriptions: List[ComposableNode],
+        context: LaunchContext
     ) -> None:
         """
         Load composable nodes sequentially.
@@ -155,8 +155,8 @@ class LoadComposableNodes(Action):
             )
 
     def execute(
-            self,
-            context: LaunchContext
+        self,
+        context: LaunchContext
     ) -> Optional[List[Action]]:
         """Execute the action."""
         # resolve target container node name


### PR DESCRIPTION
As mentioned in #75, this is my attempt to allow composing nodes in different launch files. This change allows this by making target_container also a substitution so users can pass in the container node name. That way the container node itself can be executed first in another launch file.