### PR TITLE
Make launch_testing_ros examples standalone.

### DIFF
--- a/launch_testing_ros/launch_testing_ros/examples/listener.py
+++ b/launch_testing_ros/launch_testing_ros/examples/listener.py
@@ -1,0 +1,47 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from rclpy.node import Node
+
+from std_msgs.msg import String
+
+
+class Listener(Node):
+
+    def __init__(self):
+        super().__init__('listener')
+        self.subscription = self.create_subscription(
+            String, 'chatter', self.callback, 10
+        )
+
+    def callback(self, msg):
+        self.get_logger().info('I heard: [%s]' % msg.data)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    node = Listener()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/launch_testing_ros/launch_testing_ros/examples/talker.py
+++ b/launch_testing_ros/launch_testing_ros/examples/talker.py
@@ -1,0 +1,51 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from rclpy.node import Node
+
+from std_msgs.msg import String
+
+
+class Talker(Node):
+
+    def __init__(self):
+        super().__init__('talker')
+        self.count = 0
+        self.publisher = self.create_publisher(String, 'chatter', 10)
+        self.timer = self.create_timer(1.0, self.callback)
+
+    def callback(self):
+        data = 'Hello World: {0}'.format(self.count)
+        self.get_logger().info('Publishing: "{0}"'.format(data))
+        self.publisher.publish(String(data=data))
+        self.count += 1
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    node = Talker()
+
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/launch_testing_ros/package.xml
+++ b/launch_testing_ros/package.xml
@@ -15,7 +15,6 @@
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
-  <test_depend>demo_nodes_py</test_depend>
   <test_depend>std_msgs</test_depend>
 
   <export>

--- a/launch_testing_ros/setup.cfg
+++ b/launch_testing_ros/setup.cfg
@@ -2,3 +2,7 @@
 # This will let coverage find files with 0% coverage (not hit by tests at all)
 source = .
 omit = setup.py
+[develop]
+script-dir=$base/lib/launch_testing_ros
+[install]
+install-scripts=$base/lib/launch_testing_ros

--- a/launch_testing_ros/setup.py
+++ b/launch_testing_ros/setup.py
@@ -9,11 +9,14 @@ setup(
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/launch_testing_ros']),
-        ('lib/launch_testing_ros', glob.glob('example_nodes/**')),
         ('share/launch_testing_ros', ['package.xml']),
-        ('share/launch_testing_ros/examples', glob.glob('test/examples/[!_]**')),
+        ('share/launch_testing_ros/examples', glob.glob('test/examples/[!_]*.*')),
     ],
     entry_points={
+        'console_scripts': [
+            'example_talker = launch_testing_ros.examples.talker:main',
+            'example_listener = launch_testing_ros.examples.listener:main'
+        ],
         'pytest11': ['launch_ros = launch_testing_ros.pytest.hooks'],
     },
     install_requires=['setuptools'],

--- a/launch_testing_ros/test/examples/talker_listener_launch_test.py
+++ b/launch_testing_ros/test/examples/talker_listener_launch_test.py
@@ -33,15 +33,15 @@ def generate_test_description(ready_fn):
     # will remap these topics when we launch the nodes and insert our own node that can
     # change the data as it passes through
     talker_node = launch_ros.actions.Node(
-        package='demo_nodes_py',
-        node_executable='talker',
+        package='launch_testing_ros',
+        node_executable='example_talker',
         additional_env={'PYTHONUNBUFFERED': '1'},
         remappings=[('chatter', 'talker_chatter')]
     )
 
     listener_node = launch_ros.actions.Node(
-        package='demo_nodes_py',
-        node_executable='listener',
+        package='launch_testing_ros',
+        node_executable='example_listener',
         additional_env={'PYTHONUNBUFFERED': '1'},
         remappings=[('chatter', 'listener_chatter')]
     )


### PR DESCRIPTION
Not particularly pretty but it gets rid of the circular repo dependency between `launch_ros` and `demos`. 