### PR TITLE
Fix invalid keyword argument

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -239,7 +239,7 @@ class Node(ExecuteProcess):
         node_name = entity.get_attr('node-name', optional=True)
         if node_name is not None:
             kwargs['node_name'] = node_name
-        package = parser.parse_substitution(entity.get_attr('pkg'), optional=True)
+        package = parser.parse_substitution(entity.get_attr('pkg'))
         if package is not None:
             kwargs['package'] = package
         kwargs['node_executable'] = parser.parse_substitution(entity.get_attr('exec'))


### PR DESCRIPTION
This PR fixes [Issue 88](https://github.com/ros2/launch_ros/issues/88).

It was manually verified with local testing. 

```
colcon test --packages-select test_launch_ros --event-handlers console_direct+
Starting >>> test_launch_ros
running pytest                                
running egg_info
writing /home/ANT.AMAZON.COM/dbbonnie/code/rosbag2_workspace/build/test_launch_ros/test_launch_ros.egg-info/PKG-INFO
writing dependency_links to /home/ANT.AMAZON.COM/dbbonnie/code/rosbag2_workspace/build/test_launch_ros/test_launch_ros.egg-info/dependency_links.txt
writing requirements to /home/ANT.AMAZON.COM/dbbonnie/code/rosbag2_workspace/build/test_launch_ros/test_launch_ros.egg-info/requires.txt
writing top-level names to /home/ANT.AMAZON.COM/dbbonnie/code/rosbag2_workspace/build/test_launch_ros/test_launch_ros.egg-info/top_level.txt
reading manifest file '/home/ANT.AMAZON.COM/dbbonnie/code/rosbag2_workspace/build/test_launch_ros/test_launch_ros.egg-info/SOURCES.txt'
writing manifest file '/home/ANT.AMAZON.COM/dbbonnie/code/rosbag2_workspace/build/test_launch_ros/test_launch_ros.egg-info/SOURCES.txt'
running build_ext
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-4.3.1, py-1.8.0, pluggy-0.9.0
cachedir: /home/ANT.AMAZON.COM/dbbonnie/code/rosbag2_workspace/build/test_launch_ros/.pytest_cache
rootdir: /home/ANT.AMAZON.COM/dbbonnie/code/rosbag2_workspace/rosbag2_src/ros2/launch_ros/test_launch_ros, inifile:
plugins: ament-copyright-0.8.0, ament-pep257-0.8.0, ament-flake8-0.8.0, ament-lint-0.8.0, launch-testing-ros-0.9.1, launch-testing-0.9.1, ament-xmllint-0.8.0, ament-mypy-0.8.0, rerunfailures-6.0, repeat-0.8.0, cov-2.6.1
collecting ...                                
collected 50 items                                                             

test/test_copyright.py .                                                 [  2%]
test/test_flake8.py .                                                    [  4%]
test/test_pep257.py .                                                    [  6%]
test/test_launch_ros/test_normalize_parameters.py .....................  [ 48%]
test/test_launch_ros/test_normalize_remap_rule.py .....                  [ 58%]
test/test_launch_ros/actions/test_node.py .........                      [ 76%]
test/test_launch_ros/actions/test_push_ros_namespace.py ........         [ 92%]
test/test_launch_ros/frontend/test_node_frontend.py ..                   [ 96%]
test/test_launch_ros/substitutions/test_find_package.py ..               [100%]

- generated xml file: /home/ANT.AMAZON.COM/dbbonnie/code/rosbag2_workspace/build/test_launch_ros/pytest.xml -
========================== 50 passed in 3.32 seconds ===========================
Finished <<< test_launch_ros [5.19s]          

Summary: 1 package finished [6.46s]
```
