### PR TITLE
Maintain order of parameters regarding name and from tag

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -208,7 +208,6 @@ class Node(ExecuteProcess):
             return param_dict
 
         normalized_params = []
-        params_without_from = []
         for param in params:
             from_attr = param.get_attr('from', optional=True)
             name = param.get_attr('name', optional=True)
@@ -221,11 +220,10 @@ class Node(ExecuteProcess):
                 normalized_params.append(parser.parse_substitution(from_attr))
                 continue
             elif name is not None:
-                params_without_from.append(param)
+                normalized_params.append(
+                    get_nested_dictionary_from_nested_key_value_pairs([param]))
                 continue
             raise ValueError('param Entity should have name or from attribute')
-        normalized_params.append(
-            get_nested_dictionary_from_nested_key_value_pairs(params_without_from))
         return normalized_params
 
     @classmethod

--- a/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
@@ -132,11 +132,14 @@ def test_node_frontend(file):
         ls.context,
         ld.describe_sub_entities()[2]._Node__parameters
     )
-    assert isinstance(evaluated_parameters[0], pathlib.Path)
+    assert isinstance(evaluated_parameters[0], dict)
     assert isinstance(evaluated_parameters[1], dict)
+    assert isinstance(evaluated_parameters[2], pathlib.Path)
+
+    assert 'param1' in evaluated_parameters[0]
+    assert evaluated_parameters[0]['param1'] == 'ads'
+
     param_dict = evaluated_parameters[1]
-    assert 'param1' in param_dict
-    assert param_dict['param1'] == 'ads'
     assert 'param_group1.param_group2.param2' in param_dict
     assert 'param_group1.param3' in param_dict
     assert 'param_group1.param4' in param_dict


### PR DESCRIPTION
Fixes #95 . As the title says, maintain the order of the parameters if it has the `from` or `name` tag.