### PR TITLE
Pass the node-name attribute through the substitution parser

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -238,7 +238,7 @@ class Node(ExecuteProcess):
             kwargs['arguments'] = super()._parse_cmdline(args, parser)
         node_name = entity.get_attr('node-name', optional=True)
         if node_name is not None:
-            kwargs['node_name'] = node_name
+            kwargs['node_name'] = parser.parse_substitution(node_name)
         package = entity.get_attr('pkg', optional=True)
         if package is not None:
             kwargs['package'] = parser.parse_substitution(package)


### PR DESCRIPTION
Without this, it's not possible to use substitutions in the `node-name` attribute.