### PR TITLE
Fix misleading deprecated warning when using launch arguments

### DIFF
--- a/launch_ros/launch_ros/default_launch_description.py
+++ b/launch_ros/launch_ros/default_launch_description.py
@@ -28,11 +28,12 @@ from rclpy.executors import SingleThreadedExecutor
 class ROSSpecificLaunchStartup(launch.actions.OpaqueFunction):
     """Does ROS specific launch startup."""
 
-    def __init__(self, rclpy_context=None):
+    def __init__(self, rclpy_context=None, argv=None):
         """Create a ROSSpecificLaunchStartup opaque function."""
         super().__init__(function=self._function)
         self.__shutting_down = False
         self.__rclpy_context = rclpy_context
+        self.__argv = None
 
     def _shutdown(self, event: launch.Event, context: launch.LaunchContext):
         self.__shutting_down = True
@@ -57,7 +58,7 @@ class ROSSpecificLaunchStartup(launch.actions.OpaqueFunction):
         try:
             if self.__rclpy_context is None:
                 # Initialize the default global context
-                rclpy.init(args=context.argv)
+                rclpy.init(args=self.__argv)
         except RuntimeError as exc:
             if 'rcl_init called while already initialized' in str(exc):
                 pass

--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -141,7 +141,7 @@ def launch_a_launch_file(*, launch_file_path, launch_file_arguments, debug=False
     """Launch a given launch file (by path) and pass it the given launch file arguments."""
     launch_service = launch.LaunchService(argv=launch_file_arguments, debug=debug)
     context = rclpy.context.Context()
-    rclpy.init(args=launch_file_arguments, context=context)
+    rclpy.init(args=[], context=context)
     launch_service.include_launch_description(
         launch_ros.get_default_launch_description(
             rclpy_context=context,

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -61,9 +61,6 @@ class LaunchCommand(CommandExtension):
             nargs='*',
             help="Arguments to the launch file; '<name>:=<value>' (for duplicates, last one wins)")
         arg.completer = LaunchFileNameCompleter()
-        parser.add_argument(
-            'argv', nargs=REMAINDER,
-            help='Pass arbitrary arguments to the launch file')
 
     def main(self, *, parser, args):
         """Entry point for CLI program."""


### PR DESCRIPTION
Before this patch, running:
`ros2 launch any_package any_launch_file some_arg:=some_value`
ended up with a warning:
```
[WARN] [1576175943.679492205] [rcl]: Found remap rule 'asd:=bsd'. This syntax is deprecated. Use '--ros-args --remap asd:=bsd' instead.
```

That's misleading, because the only way of passing launch arguments is by adding `key:=value` at the end of the command.

To fix this, I did the following:
- Stop using the `LaunchContext`  arguments in the initialization of the `rclpy.Context`: https://github.com/ros2/launch_ros/blob/d6dd5c0e75fb6cdbfb9b65b8468b4b0b5b2172da/launch_ros/launch_ros/default_launch_description.py#L60
  Add a custom way of passing those arguments.
- Pass no arguments in the creation of the `rclpy.Context` in `ros2launch` https://github.com/ros2/launch_ros/blob/8fae305d9aa1f4604c55de02c6224b8827cf09ee/ros2launch/ros2launch/api/api.py#L144
  Before, we were passing the same key values configurations that `ros2launch` received, which can cause problems (e.g.: being used as remapping rules).
- Finally, deleted the `argv` option of `ros2launch` arguments. IIUC, it was always empty as the previous argument (launch configurations) was taking a variable number of options.

I'm not sure if this is the correct way to go, maybe we want to do something different.
e.g.: Filtering the launch configurations from the arguments, and use the others as the arguments of the `rclpy.Context`. IMO, that may be confusing.