### PR TITLE
[Eloquent Backport] Fix linter by removing unused import

### DIFF
--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import REMAINDER
 import os
 
 from ament_index_python.packages import get_package_prefix


### PR DESCRIPTION
Backport of https://github.com/ros2/launch_ros/pull/110#issuecomment-579365342 to Eloquent