### PR TITLE
Rename node-related parameters

### DIFF
--- a/launch_ros/launch_ros/actions/composable_node_container.py
+++ b/launch_ros/launch_ros/actions/composable_node_container.py
@@ -35,8 +35,8 @@ class ComposableNodeContainer(Node):
     def __init__(
         self,
         *,
-        name: SomeSubstitutionsType = None,
-        namespace: SomeSubstitutionsType = None,
+        name: Optional[SomeSubstitutionsType] = None,
+        namespace: Optional[SomeSubstitutionsType] = None,
         node_name: Optional[SomeSubstitutionsType] = None,
         node_namespace: Optional[SomeSubstitutionsType] = None,
         composable_node_descriptions: Optional[List[ComposableNode]] = None,

--- a/launch_ros/launch_ros/actions/composable_node_container.py
+++ b/launch_ros/launch_ros/actions/composable_node_container.py
@@ -48,7 +48,8 @@ class ComposableNodeContainer(Node):
         Most arguments are forwarded to :class:`launch_ros.actions.Node`, so see the documentation
         of that class for further details.
 
-        .. warning:: Parameters `node_name` and `node_namespace` are deprecated.
+        .. deprecated:: Foxy
+           Parameters `node_name` and `node_namespace` are deprecated.
            Use `name` and `namespace` instead.
 
         :param: name the name of the node, mandatory for full container node name resolution

--- a/launch_ros/launch_ros/actions/composable_node_container.py
+++ b/launch_ros/launch_ros/actions/composable_node_container.py
@@ -16,6 +16,7 @@
 
 from typing import List
 from typing import Optional
+import warnings
 
 from launch.action import Action
 from launch.actions import RegisterEventHandler
@@ -34,8 +35,10 @@ class ComposableNodeContainer(Node):
     def __init__(
         self,
         *,
-        node_name: SomeSubstitutionsType,
-        node_namespace: SomeSubstitutionsType,
+        name: SomeSubstitutionsType = None,
+        namespace: SomeSubstitutionsType = None,
+        node_name: Optional[SomeSubstitutionsType] = None,
+        node_namespace: Optional[SomeSubstitutionsType] = None,
         composable_node_descriptions: Optional[List[ComposableNode]] = None,
         **kwargs
     ) -> None:
@@ -45,12 +48,35 @@ class ComposableNodeContainer(Node):
         Most arguments are forwarded to :class:`launch_ros.actions.Node`, so see the documentation
         of that class for further details.
 
-        :param: node_name the name of the node, mandatory for full container node name resolution
-        :param: node_namespace the ros namespace for this Node, mandatory for full container node
-           name resolution
+        .. warning:: Parameters `node_name` and `node_namespace` are deprecated.
+           Use `name` and `namespace` instead.
+
+        :param: name the name of the node, mandatory for full container node name resolution
+        :param: namespace the ROS namespace for this Node, mandatory for full container node
+             name resolution
+        :param: node_name (DEPRECATED) the name of the node, mandatory for full container node
+            name resolution
+        :param: node_namespace (DEPRECATED) the ros namespace for this Node, mandatory for full
+            container node name resolution
         :param composable_node_descriptions: optional descriptions of composable nodes to be loaded
         """
-        super().__init__(node_name=node_name, node_namespace=node_namespace, **kwargs)
+        if node_name is not None:
+            warnings.warn("The parameter 'node_name' is deprecated, use 'name' instead")
+            if name is not None:
+                raise RuntimeError(
+                    "Passing both 'node_name' and 'name' parameters. Only use 'name'."
+                )
+            name = node_name
+        if node_namespace is not None:
+            warnings.warn("The parameter 'node_namespace' is deprecated, use 'namespace' instead")
+            if namespace is not None:
+                raise RuntimeError(
+                    "Passing both 'node_namespace' and 'namespace' parameters. "
+                    "Only use 'namespace'."
+                )
+            namespace = node_namespace
+
+        super().__init__(name=name, namespace=namespace, **kwargs)
         self.__composable_node_descriptions = composable_node_descriptions
 
     def execute(self, context: LaunchContext) -> Optional[List[Action]]:

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -60,7 +60,7 @@ class LifecycleNode(Node):
             one, or even all lifecycle nodes, and it requests the targeted nodes
             to change state, see its documentation for more details.
         """
-        super().__init__(node_name=node_name, **kwargs)
+        super().__init__(name=node_name, **kwargs)
         self.__logger = launch.logging.get_logger(__name__)
         self.__rclpy_subscription = None
         self.__current_state = \

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -20,6 +20,7 @@ from typing import cast
 from typing import List
 from typing import Optional
 from typing import Text
+import warnings
 
 import launch
 from launch.action import Action
@@ -36,7 +37,7 @@ from ..events.lifecycle import StateTransition
 class LifecycleNode(Node):
     """Action that executes a ROS lifecycle node."""
 
-    def __init__(self, *, node_name: Text, **kwargs) -> None:
+    def __init__(self, *, name: Text = None, node_name: Optional[Text] = None, **kwargs) -> None:
         """
         Construct a LifecycleNode action.
 
@@ -49,7 +50,7 @@ class LifecycleNode(Node):
         - :class:`launch.events.lifecycle.StateTransition`:
 
             - this event is emitted when a message is published to the
-              "/<node_name>/transition_event" topic, indicating the lifecycle
+              "/<name>/transition_event" topic, indicating the lifecycle
               node represented by this action changed state
 
         This action also handles some events related to lifecycle:
@@ -59,8 +60,25 @@ class LifecycleNode(Node):
           - this event can be targeted to a single lifecycle node, or more than
             one, or even all lifecycle nodes, and it requests the targeted nodes
             to change state, see its documentation for more details.
+
+        .. warning:: The parameter `node_name` is deprecated, use `name` instead.
+
+        :param name: The name of the lifecycle node.
+          Although it defaults to None it is a required parameter and the default will be removed
+          in a future release.
+        :param node_name: (DEPRECATED) The name fo the lifecycle node.
         """
-        super().__init__(name=node_name, **kwargs)
+        if node_name is not None:
+            warnings.warn("The parameter 'node_name' is deprecated, use 'name' instead")
+            if name is not None:
+                raise RuntimeError(
+                    "Passing both 'node_name' and 'name' parameters. Only use 'name'."
+                )
+            name = node_name
+        # TODO(jacobperron): Remove default value and this check when deprecated API is removed
+        if name is None:
+            raise RuntimeError("'name' must not be None.'")
+        super().__init__(name=name, **kwargs)
         self.__logger = launch.logging.get_logger(__name__)
         self.__rclpy_subscription = None
         self.__current_state = \

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -67,7 +67,8 @@ class LifecycleNode(Node):
             one, or even all lifecycle nodes, and it requests the targeted nodes
             to change state, see its documentation for more details.
 
-        .. warning:: The parameter `node_name` is deprecated, use `name` instead.
+        .. deprecated:: Foxy
+           The parameter `node_name` is deprecated, use `name` instead.
 
         :param name: The name of the lifecycle node.
           Although it defaults to None it is a required parameter and the default will be removed

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -37,7 +37,13 @@ from ..events.lifecycle import StateTransition
 class LifecycleNode(Node):
     """Action that executes a ROS lifecycle node."""
 
-    def __init__(self, *, name: Text = None, node_name: Optional[Text] = None, **kwargs) -> None:
+    def __init__(
+        self,
+        *,
+        name: Optional[Text] = None,
+        node_name: Optional[Text] = None,
+        **kwargs
+    ) -> None:
         """
         Construct a LifecycleNode action.
 

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -120,7 +120,8 @@ class Node(ExecuteProcess):
         passed in in order to the node (where the last definition of a
         parameter takes effect).
 
-        .. warning:: Parameters `node_name` and `node_namespace` are deprecated.
+        .. deprecated:: Foxy
+           Parameters `node_name` and `node_namespace` are deprecated.
            Use `name` and `namespace` instead.
 
         :param: node_executable the name of the executable to find if a package

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -26,6 +26,8 @@ from typing import Text  # noqa: F401
 from typing import Tuple  # noqa: F401
 from typing import Union
 
+import warnings
+
 from launch.action import Action
 from launch.actions import ExecuteProcess
 from launch.frontend import Entity
@@ -235,6 +237,11 @@ class Node(ExecuteProcess):
         if args is not None:
             kwargs['arguments'] = super()._parse_cmdline(args, parser)
         node_name = entity.get_attr('node-name', optional=True)
+        if node_name is not None:
+            warnings.warn(
+                "The attribute 'node-name' is deprecated. Use the attribute 'name' instead.")
+            kwargs['node_name'] = parser.parse_substitution(node_name)
+        node_name = entity.get_attr('name', optional=True)
         if node_name is not None:
             kwargs['node_name'] = parser.parse_substitution(node_name)
         package = entity.get_attr('pkg', optional=True)

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -67,6 +67,7 @@ class Node(ExecuteProcess):
         namespace: Optional[SomeSubstitutionsType] = '',
         node_name: Optional[SomeSubstitutionsType] = None,
         node_namespace: SomeSubstitutionsType = '',
+        exec_name: Optional[SomeSubstitutionsType] = None,
         parameters: Optional[SomeParameters] = None,
         remappings: Optional[SomeRemapRules] = None,
         arguments: Optional[Iterable[SomeSubstitutionsType]] = None,
@@ -127,6 +128,8 @@ class Node(ExecuteProcess):
         :param: package the package in which the node executable can be found
         :param: name the name of the node
         :param: namespace the ROS namespace for this Node
+        :param: exec_name the label used to represent the process.
+            Defaults to the basename of node executable.
         :param: node_name the name of the node
         :param: node_namespace the ros namespace for this Node
         :param: parameters list of names of yaml files with parameter rules,
@@ -175,6 +178,8 @@ class Node(ExecuteProcess):
                     "ros_specific_arguments['remaps'][{}]".format(i),
                     description='remapping {}'.format(i))]
                 i += 1
+        # Forward 'exec_name' as to ExecuteProcess constructor
+        kwargs['name'] = exec_name
         super().__init__(cmd=cmd, **kwargs)
         self.__package = package
         self.__node_executable = node_executable
@@ -259,6 +264,9 @@ class Node(ExecuteProcess):
         node_name = entity.get_attr('name', optional=True)
         if node_name is not None:
             kwargs['name'] = parser.parse_substitution(node_name)
+        exec_name = entity.get_attr('exec_name', optional=True)
+        if exec_name is not None:
+            kwargs['exec_name'] = parser.parse_substitution(exec_name)
         package = entity.get_attr('pkg', optional=True)
         if package is not None:
             kwargs['package'] = parser.parse_substitution(package)

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -130,8 +130,8 @@ class Node(ExecuteProcess):
         :param: namespace the ROS namespace for this Node
         :param: exec_name the label used to represent the process.
             Defaults to the basename of node executable.
-        :param: node_name the name of the node
-        :param: node_namespace the ros namespace for this Node
+        :param: node_name (DEPRECATED) the name of the node
+        :param: node_namespace (DEPRECATED) the ros namespace for this Node
         :param: parameters list of names of yaml files with parameter rules,
             or dictionaries of parameters.
         :param: remappings ordered list of 'to' and 'from' string pairs to be

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -244,13 +244,6 @@ class Node(ExecuteProcess):
         node_name = entity.get_attr('name', optional=True)
         if node_name is not None:
             kwargs['node_name'] = parser.parse_substitution(node_name)
-            # Undo the parent action parsing 'name' as the process name
-            # For node actions, use 'exec-name' to rename the process
-            if 'name' in kwargs:
-                del kwargs['name']
-        exec_name = entity.get_attr('exec-name', optional=True)
-        if exec_name is not None:
-            kwargs['name'] = parser.parse_substitution(exec_name)
         package = entity.get_attr('pkg', optional=True)
         if package is not None:
             kwargs['package'] = parser.parse_substitution(package)

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -244,6 +244,13 @@ class Node(ExecuteProcess):
         node_name = entity.get_attr('name', optional=True)
         if node_name is not None:
             kwargs['node_name'] = parser.parse_substitution(node_name)
+            # Undo the parent action parsing 'name' as the process name
+            # For node actions, use 'exec-name' to rename the process
+            if 'name' in kwargs:
+                del kwargs['name']
+        exec_name = entity.get_attr('exec-name', optional=True)
+        if exec_name is not None:
+            kwargs['name'] = parser.parse_substitution(exec_name)
         package = entity.get_attr('pkg', optional=True)
         if package is not None:
             kwargs['package'] = parser.parse_substitution(package)

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -148,17 +148,24 @@ class Node(ExecuteProcess):
         cmd += ['--ros-args']  # Prepend ros specific arguments with --ros-args flag
         if node_name is not None:
             warnings.warn("The parameter 'node_name' is deprecated, use 'name' instead")
-            if name is None:
-                cmd += ['-r', LocalSubstitution(
-                    "ros_specific_arguments['name']", description='node name')]
-                name = node_name
+            if name is not None:
+                raise RuntimeError(
+                    "Passing both 'node_name' and 'name' parameters. Only use 'name'."
+                )
+            cmd += ['-r', LocalSubstitution(
+                "ros_specific_arguments['name']", description='node name')]
+            name = node_name
         if name is not None:
             cmd += ['-r', LocalSubstitution(
                 "ros_specific_arguments['name']", description='node name')]
         if node_namespace:
             warnings.warn("The parameter 'node_namespace' is deprecated, use 'namespace' instead")
-            if not namespace:
-                namespace = node_namespace
+            if namespace:
+                raise RuntimeError(
+                    "Passing both 'node_namespace' and 'namespace' parameters. "
+                    "Only use 'namespace'."
+                )
+            namespace = node_namespace
         if parameters is not None:
             ensure_argument_type(parameters, (list), 'parameters', 'Node')
             # All elements in the list are paths to files with parameters (or substitutions that

--- a/launch_ros/launch_ros/descriptions/composable_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_node.py
@@ -85,7 +85,6 @@ class ComposableNode:
                 )
             namespace = node_namespace
 
-
         self.__package = normalize_to_list_of_substitutions(package)
         self.__node_plugin = normalize_to_list_of_substitutions(plugin)
 

--- a/launch_ros/launch_ros/descriptions/composable_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_node.py
@@ -36,7 +36,7 @@ class ComposableNode:
     def __init__(
         self, *,
         package: SomeSubstitutionsType,
-        plugin: SomeSubstitutionsType = None,
+        plugin: Optional[SomeSubstitutionsType] = None,
         name: Optional[SomeSubstitutionsType] = None,
         namespace: Optional[SomeSubstitutionsType] = None,
         node_plugin: Optional[SomeSubstitutionsType] = None,

--- a/launch_ros/launch_ros/descriptions/composable_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_node.py
@@ -49,6 +49,10 @@ class ComposableNode:
         """
         Initialize a ComposableNode description.
 
+        .. deprecated:: Foxy
+           Parameters `node_plugin`, `node_name`, and `node_namespace` are deprecated.
+           Use `plugin`, `name`, and `namespace` instead.
+
         :param package: name of the ROS package the node plugin lives in
         :param plugin: name of the plugin to be loaded
         :param name: name to give to the ROS node

--- a/launch_ros/launch_ros/descriptions/composable_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_node.py
@@ -16,6 +16,7 @@
 
 from typing import List
 from typing import Optional
+import warnings
 
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.substitution import Substitution
@@ -35,7 +36,10 @@ class ComposableNode:
     def __init__(
         self, *,
         package: SomeSubstitutionsType,
-        node_plugin: SomeSubstitutionsType,
+        plugin: SomeSubstitutionsType = None,
+        name: Optional[SomeSubstitutionsType] = None,
+        namespace: Optional[SomeSubstitutionsType] = None,
+        node_plugin: Optional[SomeSubstitutionsType] = None,
         node_name: Optional[SomeSubstitutionsType] = None,
         node_namespace: Optional[SomeSubstitutionsType] = None,
         parameters: Optional[SomeParameters] = None,
@@ -46,23 +50,52 @@ class ComposableNode:
         Initialize a ComposableNode description.
 
         :param package: name of the ROS package the node plugin lives in
-        :param node_plugin: name of the plugin to be loaded
-        :param node_name: name the node should have
-        :param node_namespace: namespace the node should create topics/services/etc in
+        :param plugin: name of the plugin to be loaded
+        :param name: name to give to the ROS node
+        :param namespace: namespace to give to the ROS node
+        :param node_plugin: (DEPRECATED) name of the plugin to be loaded
+        :param node_name: (DEPRECATED) name the node should have
+        :param node_namespace: (DEPRECATED) namespace the node should create topics/services/etc in
         :param parameters: list of either paths to yaml files or dictionaries of parameters
         :param remappings: list of from/to pairs for remapping names
         :param extra_arguments: container specific arguments to be passed to the loaded node
         """
+        if node_plugin is not None:
+            warnings.warn("The parameter 'node_plugin' is deprecated, use 'plugin' instead")
+            if plugin is not None:
+                raise RuntimeError(
+                    "Passing both 'node_plugin' and 'plugin' parameters. Only use 'plugin'."
+                )
+            plugin = node_plugin
+        if plugin is None:
+            raise RuntimeError("The 'plugin' parameter is required")
+        if node_name is not None:
+            warnings.warn("The parameter 'node_name' is deprecated, use 'name' instead")
+            if name is not None:
+                raise RuntimeError(
+                    "Passing both 'node_name' and 'name' parameters. Only use 'name'."
+                )
+            name = node_name
+        if node_namespace is not None:
+            warnings.warn("The parameter 'node_namespace' is deprecated, use 'namespace' instead")
+            if namespace is not None:
+                raise RuntimeError(
+                    "Passing both 'node_namespace' and 'namespace' parameters. "
+                    "Only use 'namespace'."
+                )
+            namespace = node_namespace
+
+
         self.__package = normalize_to_list_of_substitutions(package)
-        self.__node_plugin = normalize_to_list_of_substitutions(node_plugin)
+        self.__node_plugin = normalize_to_list_of_substitutions(plugin)
 
         self.__node_name = None  # type: Optional[List[Substitution]]
-        if node_name is not None:
-            self.__node_name = normalize_to_list_of_substitutions(node_name)
+        if name is not None:
+            self.__node_name = normalize_to_list_of_substitutions(name)
 
         self.__node_namespace = None  # type: Optional[List[Substitution]]
-        if node_namespace is not None:
-            self.__node_namespace = normalize_to_list_of_substitutions(node_namespace)
+        if namespace is not None:
+            self.__node_namespace = normalize_to_list_of_substitutions(namespace)
 
         self.__parameters = None  # type: Optional[Parameters]
         if parameters is not None:

--- a/ros2launch/examples/example.launch.py
+++ b/ros2launch/examples/example.launch.py
@@ -29,8 +29,8 @@ def generate_launch_description():
             description='prefix for node names'),
         launch_ros.actions.Node(
             package='demo_nodes_cpp', node_executable='talker', output='screen',
-            node_name=[launch.substitutions.LaunchConfiguration('node_prefix'), 'talker']),
+            name=[launch.substitutions.LaunchConfiguration('node_prefix'), 'talker']),
         launch_ros.actions.Node(
             package='demo_nodes_cpp', node_executable='listener', output='screen',
-            node_name=[launch.substitutions.LaunchConfiguration('node_prefix'), 'listener']),
+            name=[launch.substitutions.LaunchConfiguration('node_prefix'), 'listener']),
     ])

--- a/test_launch_ros/.eggs/README.txt
+++ b/test_launch_ros/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/test_launch_ros/.eggs/README.txt
+++ b/test_launch_ros/.eggs/README.txt
@@ -1,0 +1,6 @@
+This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
+
+This directory caches those eggs to prevent repeated downloads.
+
+However, it is safe to delete this directory.
+

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -199,6 +199,20 @@ class TestNode(unittest.TestCase):
         )
         self._assert_launch_no_errors([node_action])
 
+        # Providing both 'node_name' and 'name' should throw
+        with self.assertRaises(RuntimeError):
+            launch_ros.actions.Node(
+                package='demo_nodes_py', node_executable='talker_qos', output='screen',
+                node_name='my_node', name='my_node', node_namespace='my_ns'
+            )
+
+        # Providing both 'node_namespace' and 'namespace' should throw
+        with self.assertRaises(RuntimeError):
+            launch_ros.actions.Node(
+                package='demo_nodes_py', node_executable='talker_qos', output='screen',
+                node_name='my_node', node_namespace='my_ns', namespace='my_ns'
+            )
+
     def test_launch_node_with_invalid_parameter_dicts(self):
         """Test launching a node with invalid parameter dicts."""
         # Substitutions aren't expanded until the node action is executed, at which time a type

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -45,7 +45,7 @@ class TestNode(unittest.TestCase):
             package='demo_nodes_py', node_executable='talker_qos', output='screen',
             # The node name is required for parameter dicts.
             # See https://github.com/ros2/launch/issues/139.
-            node_name='my_node', node_namespace='my_ns',
+            name='my_node', namespace='my_ns',
             arguments=['--number_of_cycles', '1'],
             parameters=parameters,
             remappings=remappings,
@@ -90,7 +90,7 @@ class TestNode(unittest.TestCase):
         # This node will never exit on its own, it'll keep publishing forever.
         long_running_node = launch_ros.actions.Node(
             package='demo_nodes_py', node_executable='talker_qos', output='screen',
-            node_namespace='my_ns',
+            namespace='my_ns',
         )
 
         # This node will exit after publishing a single message. It is required, so we
@@ -99,7 +99,7 @@ class TestNode(unittest.TestCase):
         # exit on its own.
         required_node = launch_ros.actions.Node(
             package='demo_nodes_py', node_executable='talker_qos', output='screen',
-            node_namespace='my_ns2', arguments=['--number_of_cycles', '1'],
+            namespace='my_ns2', arguments=['--number_of_cycles', '1'],
             on_exit=Shutdown()
         )
 
@@ -188,6 +188,13 @@ class TestNode(unittest.TestCase):
             package='demo_nodes_py', node_executable='talker_qos', output='screen',
             arguments=['--number_of_cycles', '1'],
             parameters=[{'my_param': 'value'}],
+        )
+        self._assert_launch_no_errors([node_action])
+
+    def test_deprecated_node_parameters(self):
+        node_action = launch_ros.actions.Node(
+            package='demo_nodes_py', node_executable='talker_qos', output='screen',
+            node_name='my_node', node_namespace='my_ns'
         )
         self._assert_launch_no_errors([node_action])
 

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -46,6 +46,7 @@ class TestNode(unittest.TestCase):
             # The node name is required for parameter dicts.
             # See https://github.com/ros2/launch/issues/139.
             name='my_node', namespace='my_ns',
+            exec_name='my_node_process',
             arguments=['--number_of_cycles', '1'],
             parameters=parameters,
             remappings=remappings,

--- a/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
@@ -37,7 +37,7 @@ xml_file = \
     <launch>
         <let name="a_string" value="\'[2, 5, 8]\'"/>
         <let name="a_list" value="[2, 5, 8]"/>
-        <node pkg="demo_nodes_py" exec="talker_qos" output="screen" name="my_talker" namespace="my_ns" args="--number_of_cycles 1">
+        <node pkg="demo_nodes_py" exec="talker_qos" output="screen" name="my_talker" namespace="my_ns" exec_name="my_talker_process" args="--number_of_cycles 1">
             <param name="param1" value="ads"/>
             <param name="param_group1">
                 <param name="param_group2">
@@ -78,6 +78,7 @@ yaml_file = \
             output: screen
             name: my_talker
             namespace: my_ns
+            exec_name: my_talker_process
             args: '--number_of_cycles 1'
             param:
                 -   name: param1

--- a/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
@@ -37,7 +37,7 @@ xml_file = \
     <launch>
         <let name="a_string" value="\'[2, 5, 8]\'"/>
         <let name="a_list" value="[2, 5, 8]"/>
-        <node pkg="demo_nodes_py" exec="talker_qos" output="screen" node-name="my_talker" namespace="my_ns" args="--number_of_cycles 1">
+        <node pkg="demo_nodes_py" exec="talker_qos" output="screen" name="my_talker" namespace="my_ns" args="--number_of_cycles 1">
             <param name="param1" value="ads"/>
             <param name="param_group1">
                 <param name="param_group2">
@@ -59,7 +59,7 @@ xml_file = \
             <remap from="foo" to="bar"/>
             <remap from="baz" to="foobar"/>
         </node>
-        <node exec="{}" args="-c 'import sys; print(sys.argv[1:])'" node-name="my_listener" namespace="my_ns" output="screen"/>
+        <node exec="{}" args="-c 'import sys; print(sys.argv[1:])'" name="my_listener" namespace="my_ns" output="screen"/>
     </launch>
     """.format(yaml_params, python_executable)  # noqa: E501
 xml_file = textwrap.dedent(xml_file)
@@ -76,7 +76,7 @@ yaml_file = \
             pkg: demo_nodes_py
             exec: talker_qos
             output: screen
-            node-name: my_talker
+            name: my_talker
             namespace: my_ns
             args: '--number_of_cycles 1'
             param:
@@ -121,7 +121,7 @@ yaml_file = \
             exec: {}
             output: screen
             namespace: my_ns
-            node-name: my_listener
+            name: my_listener
             args: -c 'import sys; print(sys.argv[1:])'
     """.format(yaml_params, python_executable)  # noqa: E501
 yaml_file = textwrap.dedent(yaml_file)


### PR DESCRIPTION
The 'node-' prefix seems redundant since the attribute is part of a "node" tag.
Add a deprecation warning in case the old name is used.

I couldn't find a reason why 'node-name' was preferred in https://github.com/ros2/launch_ros/pull/73.
I'm suggesting in this PR that we change it 'name', which seems more intuitive for me, especially coming from ROS 1.