### PR TITLE
[ros2launch] legal tab completion of launch files

### DIFF
--- a/ros2launch/ros2launch/api/__init__.py
+++ b/ros2launch/ros2launch/api/__init__.py
@@ -17,6 +17,7 @@
 from launch.launch_description_sources import InvalidLaunchFileError
 from launch.launch_description_sources import InvalidPythonLaunchFileError
 
+from .api import get_launch_file_paths
 from .api import get_share_file_path_from_package
 from .api import launch_a_launch_file
 from .api import LaunchFileNameCompleter
@@ -27,6 +28,7 @@ from .api import print_arguments_of_launch_file
 
 
 __all__ = [
+    'get_launch_file_paths',
     'get_share_file_path_from_package',
     'InvalidLaunchFileError',
     'InvalidPythonLaunchFileError',

--- a/ros2launch/ros2launch/api/__init__.py
+++ b/ros2launch/ros2launch/api/__init__.py
@@ -17,8 +17,8 @@
 from launch.launch_description_sources import InvalidLaunchFileError
 from launch.launch_description_sources import InvalidPythonLaunchFileError
 
-from .api import get_launch_file_paths
 from .api import get_share_file_path_from_package
+from .api import is_launch_file
 from .api import launch_a_launch_file
 from .api import LaunchFileNameCompleter
 from .api import MultipleLaunchFilesError
@@ -28,8 +28,8 @@ from .api import print_arguments_of_launch_file
 
 
 __all__ = [
-    'get_launch_file_paths',
     'get_share_file_path_from_package',
+    'is_launch_file',
     'InvalidLaunchFileError',
     'InvalidPythonLaunchFileError',
     'LaunchFileNameCompleter',

--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -79,7 +79,7 @@ def get_launch_file_paths(*, path):
     return launch_file_paths
 
 
-def is_launch_file(*, path):
+def is_launch_file(path):
     """Return True if the path is a launch file."""
     return path.endswith(is_launch_file.extensions) and os.path.isfile(path)
 

--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -73,16 +73,22 @@ def get_launch_file_paths(*, path):
     launch_file_paths = []
     for root, dirs, files in os.walk(path):
         for file_name in files:
-            if file_name.endswith(get_launch_file_paths.extensions):
-                launch_file_paths.append(os.path.join(root, file_name))
+            file_path = os.path.join(root, file_name)
+            if is_launch_file(path=file_path):
+                launch_file_paths.append(file_path)
     return launch_file_paths
 
 
-get_launch_file_paths.extensions = [
+def is_launch_file(*, path):
+    """Return True if the path is a launch file."""
+    return os.path.basename(path).endswith(is_launch_file.extensions) and os.path.isfile(path)
+
+
+is_launch_file.extensions = [
     'launch.' + extension for extension in Parser.get_available_extensions()
 ]
-get_launch_file_paths.extensions.append('launch.py')
-get_launch_file_paths.extensions = tuple(get_launch_file_paths.extensions)
+is_launch_file.extensions.append('launch.py')
+is_launch_file.extensions = tuple(is_launch_file.extensions)
 
 
 def print_a_launch_file(*, launch_file_path):

--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -81,7 +81,7 @@ def get_launch_file_paths(*, path):
 
 def is_launch_file(*, path):
     """Return True if the path is a launch file."""
-    return os.path.basename(path).endswith(is_launch_file.extensions) and os.path.isfile(path)
+    return path.endswith(is_launch_file.extensions) and os.path.isfile(path)
 
 
 is_launch_file.extensions = [

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -17,7 +17,11 @@ import os
 from ament_index_python.packages import get_package_prefix
 from ament_index_python.packages import PackageNotFoundError
 from argcomplete.completers import FilesCompleter
-from argcomplete.completers import SuppressCompleter
+try:
+    from argcomplete.completers import SuppressCompleter
+except ImportError:
+    # argcomplete < 1.9.0
+    SuppressCompleter = object
 from ros2cli.command import CommandExtension
 from ros2launch.api import get_share_file_path_from_package
 from ros2launch.api import is_launch_file

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -39,7 +39,7 @@ class SuppressCompleterWorkaround(SuppressCompleter):
 
 def package_name_or_launch_file_completer(prefix, parsed_args, **kwargs):
     """Complete package names or paths to launch files."""
-    pass_through_kwargs = {k: v for k, v in kwargs.items()}
+    pass_through_kwargs = dict(kwargs)
     pass_through_kwargs['prefix'] = prefix
     pass_through_kwargs['parsed_args'] = parsed_args
 

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -32,12 +32,13 @@ class SuppressCompleterWorkaround(SuppressCompleter):
     """Workaround https://github.com/kislyuk/argcomplete/pull/289 ."""
 
     def __call__(self, *args, **kwargs):
-        return tuple()
+        """Make SupressCompleter callable by returning no completions."""
+        return ()
 
 
 def package_name_or_launch_file_completer(prefix, parsed_args, **kwargs):
     # Complete package names
-    completions = [n for n in package_name_completer(prefix=prefix, **kwargs)]
+    completions = list(package_name_completer(prefix=prefix, **kwargs))
 
     # list of 2-tuples: (directory, part of prefix to prepend)
     dirs_to_check = []

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -51,7 +51,7 @@ def package_name_or_launch_file_completer(prefix, parsed_args, **kwargs):
     completions = list(package_name_completer(**pass_through_kwargs))
 
     def is_launch_file_or_dir(path):
-        return is_launch_file(path=path) or os.path.isdir(path)
+        return is_launch_file(path) or os.path.isdir(path)
 
     # Complete paths to launch files
     completions.extend(filter(is_launch_file_or_dir, FilesCompleter()(**pass_through_kwargs)))

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -61,7 +61,9 @@ def package_name_or_launch_file_completer(prefix, parsed_args, **kwargs):
     for dirname, prepend in dirs_to_check:
         # complete launch files in a directory
         for launch_file in get_launch_file_paths(path=dirname):
-            completions.append(prepend + os.path.basename(launch_file))
+            if os.path.normpath(os.path.dirname(launch_file)) == os.path.normpath(dirname):
+                # Get launch_file_paths is recursive; complete only launch files in first level
+                completions.append(prepend + os.path.basename(launch_file))
 
         # complete directories since they may contain launch files
         for path in os.listdir(path=dirname):

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -55,11 +55,11 @@ class LaunchCommand(CommandExtension):
             # TODO(wjwwood) make this not optional when full launch path is supported.
             nargs='?',
             help='Name of the launch file')
+        arg.completer = LaunchFileNameCompleter()
         arg = parser.add_argument(
             'launch_arguments',
             nargs='*',
             help="Arguments to the launch file; '<name>:=<value>' (for duplicates, last one wins)")
-        arg.completer = LaunchFileNameCompleter()
 
     def main(self, *, parser, args):
         """Entry point for CLI program."""

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -62,7 +62,7 @@ def package_name_or_launch_file_completer(prefix, parsed_args, **kwargs):
         # complete launch files in a directory
         for launch_file in get_launch_file_paths(path=dirname):
             if os.path.normpath(os.path.dirname(launch_file)) == os.path.normpath(dirname):
-                # Get launch_file_paths is recursive; complete only launch files in first level
+                # get_launch_file_paths() is recursive; complete only launch files in first level
                 completions.append(prepend + os.path.basename(launch_file))
 
         # complete directories since they may contain launch files

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -16,6 +16,7 @@ import os
 
 from ament_index_python.packages import get_package_prefix
 from ament_index_python.packages import PackageNotFoundError
+from argcomplete.completers import SuppressCompleter
 from ros2cli.command import CommandExtension
 from ros2launch.api import get_share_file_path_from_package
 from ros2launch.api import launch_a_launch_file
@@ -24,6 +25,13 @@ from ros2launch.api import MultipleLaunchFilesError
 from ros2launch.api import print_a_launch_file
 from ros2launch.api import print_arguments_of_launch_file
 from ros2pkg.api import package_name_completer
+
+
+class SuppressCompleterWorkaround(SuppressCompleter):
+    """Workaround https://github.com/kislyuk/argcomplete/pull/289 ."""
+
+    def __call__(self, *args, **kwargs):
+        return tuple()
 
 
 class LaunchCommand(CommandExtension):
@@ -60,6 +68,7 @@ class LaunchCommand(CommandExtension):
             'launch_arguments',
             nargs='*',
             help="Arguments to the launch file; '<name>:=<value>' (for duplicates, last one wins)")
+        arg.completer = SuppressCompleterWorkaround()
 
     def main(self, *, parser, args):
         """Entry point for CLI program."""


### PR DESCRIPTION
Fixes #118 

This fixes one issue, but it took multiple steps:
* `LaunchFileNameCompleter` belongs on the `launch_file_name` argument, not `launch_arguments`.
* Suppress completions of `launch_arguments`, since by default it completes all files in the current directory
* Expose `get_launch_file_paths` so I can use it in a new completer
* Add a completer that allows first argument to be either a package name or a launch file

Here's the folder structure I used for testing
```
$ tree
.
├── composition
│   ├── asdf.launch.py
│   ├── foo
│   │   ├── bar.launch.py
│   │   └── baz.launch.py
│   └── foo.launch.py
└── composition_launch.py

2 directories, 5 files
```

Here are the completions I tested with this PR

```
$ ros2 launch com<tab><tab>
common_interfaces       composition             composition/            composition_interfaces  composition_launch.py
$ ros2 launch composition<tab><tab>
composition             composition/            composition_interfaces  composition_launch.py
$ ros2 launch composition <tab><tab>
-a                              --debug                         --print-description             --show-args
composition_demo.launch.py      -p                              -s                              --show-arguments
-d                              --print                         --show-all-subprocesses-output
$ ros2 launch composition c<tab>(v completes to v)
$ ros2 launch composition composition_demo.launch.py
$ ros2 launch composition/<tab><tab>
composition/asdf.launch.py  composition/foo/            composition/foo.launch.py
$ ros2 launch composition/foo<tab><tab>
composition/foo/           composition/foo.launch.py
$ ros2 launch composition/foo/<tab>(v completes to v)
$ ros2 launch composition/foo/ba
$ ros2 launch composition/foo/baz<tab>(vcompletes to v)
$ ros2 launch composition/foo/baz.launch.py
```
