### PR TITLE
Remove unused 'launch' import.

### DIFF
--- a/launch_testing_ros/launch_testing_ros/test_runner.py
+++ b/launch_testing_ros/launch_testing_ros/test_runner.py
@@ -14,7 +14,6 @@
 
 """Module for a ROS aware LaunchTestRunner."""
 
-import launch
 import launch_testing.test_runner
 
 


### PR DESCRIPTION
Precisely what the title says. Follow-up after #128, I missed a `flake8` warning that the buildfarmer then caught.

CI up to `launch_testing_ros`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9683)](http://ci.ros2.org/job/ci_linux/9683/)