### PR TITLE
show error strings as part of the flake8 test

### DIFF
--- a/launch_testing_ros/test/test_flake8.py
+++ b/launch_testing_ros/test/test_flake8.py
@@ -17,4 +17,6 @@ from ament_flake8.main import main
 
 def test_flake8():
     rc = main(argv=[])
-    assert rc == 0, 'Found code style errors / warnings'
+    assert rc == 0, \
+        'Found %d code style errors / warnings:' % len(rc.error_strings) + \
+        ''.join('\n' + e for e in rc.error_strings)

--- a/launch_testing_ros/test/test_flake8.py
+++ b/launch_testing_ros/test/test_flake8.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_flake8.main import main
+from ament_flake8.main import main_with_errors
 
 
 def test_flake8():
-    rc = main(argv=[])
+    rc, errors = main_with_errors(argv=[])
     assert rc == 0, \
-        'Found %d code style errors / warnings:' % len(rc.error_strings) + \
-        ''.join('\n' + e for e in rc.error_strings)
+        'Found %d code style errors / warnings:\n' % len(errors) + \
+        '\n'.join(errors)


### PR DESCRIPTION
Uses the ~~modified return code~~ new API from ament/ament_lint#221 to show all actual error string.

Before - just showing the return code: https://ci.ros2.org/job/ci_linux/9685/testReport/launch_testing_ros.test/test_flake8/test_flake8/
After - enumerating the actual error messages: https://ci.ros2.org/job/ci_linux/9686/testReport/launch_testing_ros.test/test_flake8/test_flake8/