### PR TITLE
Deprecated 'node_executable' parameter and replace with 'executable'

### DIFF
--- a/launch_ros/examples/lifecycle_pub_sub_launch.py
+++ b/launch_ros/examples/lifecycle_pub_sub_launch.py
@@ -37,7 +37,7 @@ def main(argv=sys.argv[1:]):
     # Prepare the talker node.
     talker_node = launch_ros.actions.LifecycleNode(
         node_name='talker',
-        package='lifecycle', node_executable='lifecycle_talker', output='screen')
+        package='lifecycle', executable='lifecycle_talker', output='screen')
 
     # When the talker reaches the 'inactive' state, make it take the 'activate' transition.
     register_event_handler_for_talker_reaches_inactive_state = launch.actions.RegisterEventHandler(
@@ -63,7 +63,7 @@ def main(argv=sys.argv[1:]):
                     msg="node 'talker' reached the 'active' state, launching 'listener'."),
                 launch_ros.actions.LifecycleNode(
                     node_name='listener',
-                    package='lifecycle', node_executable='lifecycle_listener', output='screen'),
+                    package='lifecycle', executable='lifecycle_listener', output='screen'),
             ],
         )
     )

--- a/launch_ros/examples/pub_sub_launch.py
+++ b/launch_ros/examples/pub_sub_launch.py
@@ -30,10 +30,10 @@ def main(argv=sys.argv[1:]):
     """Run demo nodes via launch."""
     ld = LaunchDescription([
         launch_ros.actions.Node(
-            package='demo_nodes_cpp', node_executable='talker', output='screen',
+            package='demo_nodes_cpp', executable='talker', output='screen',
             remappings=[('chatter', 'my_chatter')]),
         launch_ros.actions.Node(
-            package='demo_nodes_cpp', node_executable='listener', output='screen',
+            package='demo_nodes_cpp', executable='listener', output='screen',
             remappings=[('chatter', 'my_chatter')]),
     ])
 

--- a/launch_testing_ros/test/examples/talker_listener_launch_test.py
+++ b/launch_testing_ros/test/examples/talker_listener_launch_test.py
@@ -40,14 +40,14 @@ def generate_test_description():
     path_to_test = os.path.dirname(__file__)
 
     talker_node = launch_ros.actions.Node(
-        node_executable=sys.executable,
+        executable=sys.executable,
         arguments=[os.path.join(path_to_test, 'talker.py')],
         additional_env={'PYTHONUNBUFFERED': '1'},
         remappings=[('chatter', 'talker_chatter')]
     )
 
     listener_node = launch_ros.actions.Node(
-        node_executable=sys.executable,
+        executable=sys.executable,
         arguments=[os.path.join(path_to_test, 'listener.py')],
         additional_env={'PYTHONUNBUFFERED': '1'},
         remappings=[('chatter', 'listener_chatter')]

--- a/ros2launch/examples/example.launch.py
+++ b/ros2launch/examples/example.launch.py
@@ -28,9 +28,9 @@ def generate_launch_description():
             default_value=[launch.substitutions.EnvironmentVariable('USER'), '_'],
             description='prefix for node names'),
         launch_ros.actions.Node(
-            package='demo_nodes_cpp', node_executable='talker', output='screen',
+            package='demo_nodes_cpp', executable='talker', output='screen',
             name=[launch.substitutions.LaunchConfiguration('node_prefix'), 'talker']),
         launch_ros.actions.Node(
-            package='demo_nodes_cpp', node_executable='listener', output='screen',
+            package='demo_nodes_cpp', executable='listener', output='screen',
             name=[launch.substitutions.LaunchConfiguration('node_prefix'), 'listener']),
     ])

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -42,7 +42,7 @@ class TestNode(unittest.TestCase):
 
     def _create_node(self, *, parameters=None, remappings=None):
         return launch_ros.actions.Node(
-            package='demo_nodes_py', node_executable='talker_qos', output='screen',
+            package='demo_nodes_py', executable='talker_qos', output='screen',
             # The node name is required for parameter dicts.
             # See https://github.com/ros2/launch/issues/139.
             name='my_node', namespace='my_ns',
@@ -59,7 +59,7 @@ class TestNode(unittest.TestCase):
     def test_launch_invalid_node(self):
         """Test launching an invalid node."""
         node_action = launch_ros.actions.Node(
-            package='nonexistent_package', node_executable='node', output='screen')
+            package='nonexistent_package', executable='node', output='screen')
         self._assert_launch_errors([node_action])
 
     def test_launch_node(self):
@@ -90,7 +90,7 @@ class TestNode(unittest.TestCase):
     def test_launch_required_node(self):
         # This node will never exit on its own, it'll keep publishing forever.
         long_running_node = launch_ros.actions.Node(
-            package='demo_nodes_py', node_executable='talker_qos', output='screen',
+            package='demo_nodes_py', executable='talker_qos', output='screen',
             namespace='my_ns',
         )
 
@@ -99,7 +99,7 @@ class TestNode(unittest.TestCase):
         # bring down the whole launched system, including the above node that will never
         # exit on its own.
         required_node = launch_ros.actions.Node(
-            package='demo_nodes_py', node_executable='talker_qos', output='screen',
+            package='demo_nodes_py', executable='talker_qos', output='screen',
             namespace='my_ns2', arguments=['--number_of_cycles', '1'],
             on_exit=Shutdown()
         )
@@ -186,7 +186,7 @@ class TestNode(unittest.TestCase):
 
         # If a parameter dictionary is specified, the node name is no longer required.
         node_action = launch_ros.actions.Node(
-            package='demo_nodes_py', node_executable='talker_qos', output='screen',
+            package='demo_nodes_py', executable='talker_qos', output='screen',
             arguments=['--number_of_cycles', '1'],
             parameters=[{'my_param': 'value'}],
         )
@@ -198,6 +198,13 @@ class TestNode(unittest.TestCase):
             node_name='my_node', node_namespace='my_ns'
         )
         self._assert_launch_no_errors([node_action])
+
+        # Providing both 'node_executable' and 'executable' should throw
+        with self.assertRaises(RuntimeError):
+            launch_ros.actions.Node(
+                package='demo_nodes_py', node_executable='talker_qos', executable='talker_qos',
+                output='screen', node_name='my_node', node_namespace='my_ns'
+            )
 
         # Providing both 'node_name' and 'name' should throw
         with self.assertRaises(RuntimeError):

--- a/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
@@ -78,7 +78,7 @@ def test_push_ros_namespace(config):
         pns2.execute(lc)
     node = Node(
         package='dont_care',
-        node_executable='whatever',
+        executable='whatever',
         node_namespace=config.node_ns,
     )
     node._perform_substitutions(lc)

--- a/test_launch_ros/test/test_launch_ros/test_track_node_names.py
+++ b/test_launch_ros/test/test_launch_ros/test_track_node_names.py
@@ -58,7 +58,7 @@ def _launch(launch_description):
 def test_launch_node_with_name():
     node = Node(
         package='demo_nodes_py',
-        node_executable='listener_qos',
+        executable='listener_qos',
         node_name=TEST_NODE_NAME,
         node_namespace=TEST_NODE_NAMESPACE,
         output='screen',
@@ -72,7 +72,7 @@ def test_launch_node_with_name():
 def test_launch_node_without_name():
     node = Node(
         package='demo_nodes_py',
-        node_executable='listener_qos',
+        executable='listener_qos',
         node_namespace=TEST_NODE_NAMESPACE,
         output='screen',
     )
@@ -86,7 +86,7 @@ def test_launch_node_without_name():
 def test_launch_node_with_name_without_namespace():
     node = Node(
         package='demo_nodes_py',
-        node_executable='listener_qos',
+        executable='listener_qos',
         node_name=TEST_NODE_NAME,
         output='screen',
     )
@@ -99,7 +99,7 @@ def test_launch_node_with_name_without_namespace():
 def test_launch_composable_node_with_names(pytestconfig):
     node = ComposableNodeContainer(
         package='rclcpp_components',
-        node_executable='component_container',
+        executable='component_container',
         node_name=TEST_NODE_NAME,
         node_namespace=TEST_NODE_NAMESPACE,
         composable_node_descriptions=[
@@ -124,7 +124,7 @@ def test_launch_composable_node_with_names(pytestconfig):
 def test_launch_composable_node_without_component_name():
     node = ComposableNodeContainer(
         package='rclcpp_components',
-        node_executable='component_container',
+        executable='component_container',
         node_name=TEST_NODE_NAME,
         node_namespace=TEST_NODE_NAMESPACE,
         composable_node_descriptions=[
@@ -147,7 +147,7 @@ def test_launch_composable_node_without_component_name():
 def test_launch_nodes_with_same_names(pytestconfig):
     node1 = Node(
         package='demo_nodes_py',
-        node_executable='listener_qos',
+        executable='listener_qos',
         node_name=TEST_NODE_NAME,
         node_namespace=TEST_NODE_NAMESPACE,
         output='screen',
@@ -155,7 +155,7 @@ def test_launch_nodes_with_same_names(pytestconfig):
 
     node2 = LifecycleNode(
         package='lifecycle',
-        node_executable='lifecycle_listener',
+        executable='lifecycle_listener',
         node_name=TEST_NODE_NAME,
         node_namespace=TEST_NODE_NAMESPACE,
         output='screen',
@@ -163,7 +163,7 @@ def test_launch_nodes_with_same_names(pytestconfig):
 
     node3 = ComposableNodeContainer(
         package='rclcpp_components',
-        node_executable='component_container',
+        executable='component_container',
         node_name=TEST_NODE_NAME,
         node_namespace=TEST_NODE_NAMESPACE,
         composable_node_descriptions=[
@@ -189,7 +189,7 @@ def test_launch_nodes_with_same_names(pytestconfig):
 def test_launch_nodes_with_different_names():
     node1 = Node(
         package='demo_nodes_py',
-        node_executable='listener_qos',
+        executable='listener_qos',
         node_name=f'{TEST_NODE_NAME}_1',
         node_namespace=TEST_NODE_NAMESPACE,
         output='screen',
@@ -197,7 +197,7 @@ def test_launch_nodes_with_different_names():
 
     node2 = LifecycleNode(
         package='lifecycle',
-        node_executable='lifecycle_listener',
+        executable='lifecycle_listener',
         node_name=f'{TEST_NODE_NAME}_2',
         node_namespace=TEST_NODE_NAMESPACE,
         output='screen',
@@ -205,7 +205,7 @@ def test_launch_nodes_with_different_names():
 
     node3 = ComposableNodeContainer(
         package='rclcpp_components',
-        node_executable='component_container',
+        executable='component_container',
         node_name=f'{TEST_NODE_NAME}_3',
         node_namespace=TEST_NODE_NAMESPACE,
         composable_node_descriptions=[


### PR DESCRIPTION
This is a follow-up to https://github.com/ros2/launch_ros/pull/122.

If 'node_executable' is used then a deprecation warning is issued.
If 'node_executable' is used at the same time as 'executable', then a
runtime error is raised. This is similar behaviour to the other
parameters deprecated in https://github.com/ros2/launch_ros/pull/122.