### PR TITLE
Avoid using sys.argv in rclpy.init for the RosAdapters Node

### DIFF
--- a/launch_ros/launch_ros/ros_adapters.py
+++ b/launch_ros/launch_ros/ros_adapters.py
@@ -41,7 +41,8 @@ class ROSAdapter:
         :param: argv List of global arguments for rclpy context initialization.
         :param: autostart Whether to start adapter on construction or not.
         """
-        self.__argv = argv
+        # Do not use `None` here, as `rclpy.init` will use `sys.argv` in that case.
+        self.__argv = [] if argv is None else argv
         self.__ros_context = None
         self.__ros_node = None
         self.__ros_executor = None


### PR DESCRIPTION
Fixes https://github.com/ros2/launch_ros/pull/106#issuecomment-617917881.

I was thinking on a regression test, but capturing the output to check if the warning was print doesn't sound like a correct solution, as they are temporal (talking about that: @hidmic should the support of the old command line arguments be deleted for Foxy or for G-Turtle?).

Currently, `rclpy` doesn't provide a way to introspect the arguments that were used to initialize a [Context](https://github.com/ros2/rclpy/blob/b8209da94996f09ea375380549e7305bd81d4b83/rclpy/rclpy/context.py#L23), so I don't see a good way of adding a regression test (without also adding that minimal enhancement in `rclpy`)).