### PR TITLE
Fix test_node_frontend

### DIFF
--- a/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
@@ -1,5 +1,5 @@
-# Copyright 2019 Open Source Robotics Foundation, Inc.
 # Copyright 2020 Rover Robotics c/o Dan Rose
+# Copyright 2019 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
@@ -1,5 +1,5 @@
-# Copyright 2020 Rover Robotics c/o Dan Rose
 # Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2020 Open Avatar Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2020 Rover Robotics c/o Dan Rose
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""Example of how to parse an xml."""
 
 import io
 import pathlib
@@ -31,7 +30,7 @@ yaml_params = yaml_params.replace('\\', '\\\\')
 python_executable = sys.executable.replace('\\', '\\\\')
 
 
-def test_node_frontend_xml():
+def test_launch_remapping_xml():
     xml_file = textwrap.dedent(
         r"""
         <launch>
@@ -64,10 +63,10 @@ def test_node_frontend_xml():
         """.format(yaml_params, python_executable))  # noqa: E501
 
     with io.StringIO(xml_file) as f:
-        validate_launch_result(f)
+        check_launch_remapping(f)
 
 
-def test_node_frontend_yaml():
+def test_launch_remapping_yaml():
     yaml_file = textwrap.dedent(
         r"""
         launch:
@@ -132,11 +131,10 @@ def test_node_frontend_yaml():
         """.format(yaml_params, python_executable))  # noqa: E501
 
     with io.StringIO(yaml_file) as f:
-        validate_launch_result(f)
+        check_launch_remapping(f)
 
 
-def validate_launch_result(file):
-    """Parse node xml example."""
+def check_launch_remapping(file):
     root_entity, parser = Parser.load(file)
     ld = parser.parse_description(root_entity)
     ls = LaunchService()

--- a/test_launch_ros/test/test_launch_ros/frontend/test_push_ros_namespace_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_push_ros_namespace_frontend.py
@@ -20,28 +20,32 @@ import textwrap
 from launch import LaunchService
 from launch.frontend import Parser
 
-import pytest
 
-xml_file = \
-    r"""
-    <launch>
-        <push-ros-namespace namespace="asd"/>
-    </launch>
-    """
-xml_file = textwrap.dedent(xml_file)
-yaml_file = \
+def test_launch_namespace_yaml():
+    yaml_file = textwrap.dedent(
     r"""
     launch:
-        - push-ros-namespace:
-            namespace: 'asd'
+       - push-ros-namespace:
+           namespace: 'asd'
     """
-yaml_file = textwrap.dedent(yaml_file)
+    )
+    with io.StringIO(yaml_file) as f:
+        check_launch_namespace(f)
 
 
-@pytest.mark.parametrize('file', (xml_file, yaml_file))
-def test_node_frontend(file):
-    """Parse node xml example."""
-    root_entity, parser = Parser.load(io.StringIO(file))
+def test_launch_namespace_xml():
+    xml_file = textwrap.dedent(
+        r"""
+        <launch>
+            <push-ros-namespace namespace="asd"/>
+        </launch>
+        """)
+    with io.StringIO(xml_file) as f:
+        check_launch_namespace(f)
+
+
+def check_launch_namespace(file):
+    root_entity, parser = Parser.load(file)
     ld = parser.parse_description(root_entity)
     ls = LaunchService()
     ls.include_launch_description(ld)

--- a/test_launch_ros/test/test_launch_ros/frontend/test_push_ros_namespace_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_push_ros_namespace_frontend.py
@@ -1,5 +1,5 @@
-# Copyright 2020 Rover Robotics, c/o Dan Rose
 # Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2020 Open Avatar Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test_launch_ros/test/test_launch_ros/frontend/test_push_ros_namespace_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_push_ros_namespace_frontend.py
@@ -22,11 +22,11 @@ from launch.frontend import Parser
 
 def test_launch_namespace_yaml():
     yaml_file = textwrap.dedent(
-    r"""
-    launch:
-       - push-ros-namespace:
-           namespace: 'asd'
-    """
+        r"""
+        launch:
+           - push-ros-namespace:
+               namespace: 'asd'
+        """
     )
     with io.StringIO(yaml_file) as f:
         check_launch_namespace(f)
@@ -38,7 +38,8 @@ def test_launch_namespace_xml():
         <launch>
             <push-ros-namespace namespace="asd"/>
         </launch>
-        """)
+        """
+    )
     with io.StringIO(xml_file) as f:
         check_launch_namespace(f)
 

--- a/test_launch_ros/test/test_launch_ros/frontend/test_push_ros_namespace_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_push_ros_namespace_frontend.py
@@ -1,3 +1,4 @@
+# Copyright 2020 Rover Robotics, c/o Dan Rose
 # Copyright 2019 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test_launch_ros/test/test_launch_ros/frontend/test_push_ros_namespace_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_push_ros_namespace_frontend.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Example of how to parse an xml."""
-
 import io
 import textwrap
 


### PR DESCRIPTION
Fix #145

1. Make test names more intelligible by not parameterizing on a crazy long string
2. Don't leak StringIO objects
Signed-off-by: Dan Rose <dan@digilabs.io>

