### PR TITLE
Call LaunchROSTestModule with the new API.

### DIFF
--- a/launch_testing_ros/launch_testing_ros/pytest/hooks.py
+++ b/launch_testing_ros/launch_testing_ros/pytest/hooks.py
@@ -38,7 +38,7 @@ class LaunchROSTestModule(LaunchTestModule):
 def pytest_launch_collect_makemodule(path, parent, entrypoint):
     marks = getattr(entrypoint, 'pytestmark', [])
     if marks and any(m.name == 'rostest' for m in marks):
-        return LaunchROSTestModule(path, parent)
+        return LaunchROSTestModule.from_parent(parent=parent, fspath=path)
 
 
 def pytest_configure(config):


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This goes along with ros2/launch#421 (and the CI is over there as well).