### PR TITLE
Add pytest.ini so local tests don't display warning

### DIFF
--- a/launch_ros/pytest.ini
+++ b/launch_ros/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/launch_testing_ros/pytest.ini
+++ b/launch_testing_ros/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 # Set testpaths, otherwise pytest finds 'tests' in the examples directory
 testpaths = test
+junit_family=xunit2

--- a/ros2launch/pytest.ini
+++ b/ros2launch/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/test_launch_ros/pytest.ini
+++ b/test_launch_ros/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

See https://github.com/ros2/ros2/issues/951 for more details and CI.