### PR TITLE
Fix no specified namespace

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -352,11 +352,11 @@ class Node(ExecuteProcess):
                 expanded_node_namespace = perform_substitutions(
                     context, normalize_to_list_of_substitutions(self.__node_namespace))
             base_ns = context.launch_configurations.get('ros_namespace', None)
-            if any(x is not None for x in (base_ns, expanded_node_namespace)):
-                expanded_node_namespace = (
-                    '' if expanded_node_namespace is None else expanded_node_namespace
-                )
-                base_ns = '' if base_ns is None else base_ns
+            if base_ns is not None or expanded_node_namespace is not None:
+                if expanded_node_namespace is None:
+                    expanded_node_namespace = ''
+                if base_ns is None:
+                    base_ns = ''
                 if not expanded_node_namespace.startswith('/'):
                     expanded_node_namespace = (
                         base_ns + '/' + expanded_node_namespace
@@ -380,10 +380,8 @@ class Node(ExecuteProcess):
             )
             raise
         self.__final_node_name = ''
-        if self.__expanded_node_namespace not in ['', '/']:
+        if self.__expanded_node_namespace != '/':
             self.__final_node_name += self.__expanded_node_namespace
-        elif self.__expanded_node_namespace == '':
-            self.__final_node_name += self.UNSPECIFIED_NODE_NAMESPACE
         self.__final_node_name += '/' + self.__expanded_node_name
         # expand parameters too
         if self.__parameters is not None:

--- a/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
@@ -27,7 +27,7 @@ class Config:
     def __init__(
         self,
         *,
-        node_ns='',
+        node_ns=None,
         push_ns=None,
         expected_ns=None,
         second_push_ns=None
@@ -66,7 +66,9 @@ class Config:
         node_ns='node_ns',
         expected_ns='/absolute_ns/node_ns'),
     Config(),
-    Config(push_ns=''),
+    Config(
+        push_ns='',
+        expected_ns='/'),
 ))
 def test_push_ros_namespace(config):
     lc = LaunchContext()
@@ -82,5 +84,7 @@ def test_push_ros_namespace(config):
         namespace=config.node_ns,
     )
     node._perform_substitutions(lc)
-    expected_ns = config.expected_ns if config.expected_ns is not None else ''
+    expected_ns = (
+        config.expected_ns if config.expected_ns is not None else Node.UNSPECIFIED_NODE_NAMESPACE
+    )
     assert expected_ns == node.expanded_node_namespace

--- a/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
@@ -27,11 +27,13 @@ class Config:
     def __init__(
         self,
         *,
+        node_name=None,
         node_ns=None,
         push_ns=None,
         expected_ns=None,
         second_push_ns=None
     ):
+        self.node_name = node_name
         self.push_ns = push_ns
         self.node_ns = node_ns
         self.expected_ns = expected_ns
@@ -65,6 +67,16 @@ class Config:
         second_push_ns='/absolute_ns',
         node_ns='node_ns',
         expected_ns='/absolute_ns/node_ns'),
+    Config(
+        node_name='my_node',
+        push_ns='relative_ns',
+        second_push_ns='/absolute_ns',
+        node_ns='node_ns',
+        expected_ns='/absolute_ns/node_ns'),
+    Config(
+        node_name='my_node',
+        node_ns='node_ns',
+        expected_ns='/node_ns'),
     Config(),
     Config(
         push_ns='',
@@ -82,9 +94,15 @@ def test_push_ros_namespace(config):
         package='dont_care',
         executable='whatever',
         namespace=config.node_ns,
+        name=config.node_name
     )
     node._perform_substitutions(lc)
     expected_ns = (
         config.expected_ns if config.expected_ns is not None else Node.UNSPECIFIED_NODE_NAMESPACE
     )
+    expected_name = (
+        config.node_name if config.node_name is not None else Node.UNSPECIFIED_NODE_NAME
+    )
+    expected_fqn = expected_ns.rstrip('/') + '/' + expected_name
     assert expected_ns == node.expanded_node_namespace
+    assert expected_fqn == node.node_name

--- a/test_launch_ros/test/test_launch_ros/test_track_node_names.py
+++ b/test_launch_ros/test/test_launch_ros/test_track_node_names.py
@@ -93,7 +93,7 @@ def test_launch_node_with_name_without_namespace():
     ld = LaunchDescription([node])
     context = _launch(ld)
     assert get_node_name_count(context, f'{TEST_NODE_NAMESPACE}/{TEST_NODE_NAME}') == 0
-    assert get_node_name_count(context, f'/{TEST_NODE_NAME}') == 1
+    assert get_node_name_count(context, f'/{TEST_NODE_NAME}') == 0
 
 
 def test_launch_composable_node_with_names(pytestconfig):


### PR DESCRIPTION
If the user doesn't explicitly pass a namespace to `Node` action neither uses `PushRosNamespace`, the node namespace can't be known at launch time neither the fully qualified node name:

https://github.com/ros2/launch_ros/blob/7974bd4baa545dc821b5afbda9c82fbc74647df7/launch_ros/launch_ros/actions/node.py#L355-L358

This PR fixes that incorrect assumption.