### PR TITLE
Avoid passing parameters using a wildcard if fully qualified node name is known at launch time

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -331,8 +331,10 @@ class Node(ExecuteProcess):
     def _create_params_file_from_dict(self, params):
         with NamedTemporaryFile(mode='w', prefix='launch_params_', delete=False) as h:
             param_file_path = h.name
-            # TODO(dhood): clean up generated parameter files.
-            param_dict = {'/**': {'ros__parameters': params}}
+            param_dict = {
+                self.node_name if self.is_node_name_fully_specified() else '/**':
+                {'ros__parameters': params}
+            }
             yaml.dump(param_dict, h, default_flow_style=False)
             return param_file_path
 

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -165,7 +165,7 @@ class TestNode(unittest.TestCase):
         with open(expanded_parameter_files[0], 'r') as h:
             expanded_parameters_dict = yaml.load(h, Loader=yaml.FullLoader)
             assert expanded_parameters_dict == {
-                '/**': {
+                '/my_ns/my_node': {
                     'ros__parameters': {
                         'param1': 'param1_value',
                         'param2': 'param2_value',


### PR DESCRIPTION
This can be considered a fix of the problem described [here](https://github.com/ros2/rclcpp/issues/953#issuecomment-642784377).

This only solves the problem if both `name` and `namespace` were explicitly specified at launch.
If we finally decide to also change `rcl` behavior, this change doesn't do any harm.

Depends on https://github.com/ros2/launch_ros/pull/153.