### PR TITLE
Remove the loop parameter from async.sleep.

### DIFF
--- a/test_launch_ros/test/test_launch_ros/test_track_node_names.py
+++ b/test_launch_ros/test/test_launch_ros/test_track_node_names.py
@@ -48,7 +48,7 @@ def _launch(launch_description):
     ls = LaunchService()
     ls.include_launch_description(launch_description)
     launch_task = loop.create_task(ls.run_async())
-    loop.run_until_complete(asyncio.sleep(5, loop=loop))
+    loop.run_until_complete(asyncio.sleep(5))
     if not launch_task.done():
         loop.create_task(ls.shutdown())
         loop.run_until_complete(launch_task)


### PR DESCRIPTION
This removes a warning of the form:

test/test_launch_ros/test_track_node_names.py::test_launch_nodes_with_different_names
  Warning: The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>