### PR TITLE
Make namespace parameter mandatory in LifecycleNode constructor

### DIFF
--- a/launch_ros/examples/lifecycle_pub_sub_launch.py
+++ b/launch_ros/examples/lifecycle_pub_sub_launch.py
@@ -62,7 +62,7 @@ def main(argv=sys.argv[1:]):
                 launch.actions.LogInfo(
                     msg="node 'talker' reached the 'active' state, launching 'listener'."),
                 launch_ros.actions.LifecycleNode(
-                    name='listener', namespace=''
+                    name='listener', namespace='',
                     package='lifecycle', executable='lifecycle_listener', output='screen'),
             ],
         )

--- a/launch_ros/examples/lifecycle_pub_sub_launch.py
+++ b/launch_ros/examples/lifecycle_pub_sub_launch.py
@@ -36,7 +36,7 @@ def main(argv=sys.argv[1:]):
 
     # Prepare the talker node.
     talker_node = launch_ros.actions.LifecycleNode(
-        node_name='talker',
+        name='talker', namespace='',
         package='lifecycle', executable='lifecycle_talker', output='screen')
 
     # When the talker reaches the 'inactive' state, make it take the 'activate' transition.
@@ -62,7 +62,7 @@ def main(argv=sys.argv[1:]):
                 launch.actions.LogInfo(
                     msg="node 'talker' reached the 'active' state, launching 'listener'."),
                 launch_ros.actions.LifecycleNode(
-                    node_name='listener',
+                    name='listener', namespace=''
                     package='lifecycle', executable='lifecycle_listener', output='screen'),
             ],
         )

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -23,6 +23,7 @@ from typing import Text
 import warnings
 
 import launch
+from launch import SomeSubstitutionsType
 from launch.action import Action
 import launch.logging
 
@@ -42,8 +43,9 @@ class LifecycleNode(Node):
     def __init__(
         self,
         *,
-        name: Optional[Text] = None,
-        node_name: Optional[Text] = None,
+        name: Optional[SomeSubstitutionsType] = None,
+        namespace: SomeSubstitutionsType = '',
+        node_name: Optional[SomeSubstitutionsType] = None,
         **kwargs
     ) -> None:
         """
@@ -87,7 +89,7 @@ class LifecycleNode(Node):
         # TODO(jacobperron): Remove default value and this check when deprecated API is removed
         if name is None:
             raise RuntimeError("'name' must not be None.'")
-        super().__init__(name=name, **kwargs)
+        super().__init__(name=name, namespace=namespace, **kwargs)
         self.__logger = launch.logging.get_logger(__name__)
         self.__rclpy_subscription = None
         self.__current_state = \

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -43,7 +43,7 @@ class LifecycleNode(Node):
         self,
         *,
         name: Optional[SomeSubstitutionsType] = None,
-        namespace: SomeSubstitutionsType = '',
+        namespace: SomeSubstitutionsType,
         node_name: Optional[SomeSubstitutionsType] = None,
         **kwargs
     ) -> None:

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -19,7 +19,6 @@ import threading
 from typing import cast
 from typing import List
 from typing import Optional
-from typing import Text
 import warnings
 
 import launch

--- a/test_launch_ros/test/test_launch_ros/actions/test_lifecycle_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_lifecycle_node.py
@@ -21,14 +21,14 @@ import pytest
 
 
 def test_lifecycle_node_constructor():
-    # Construction without name
+    # Construction without namespace
     with pytest.raises(TypeError):
         LifecycleNode(
             package='asd',
             executable='bsd',
             name='my_node',
         )
-    # Construction without namespace
+    # Construction without name
     # TODO(ivanpauno): This should raise TypeError.
     with pytest.raises(RuntimeError):
         LifecycleNode(

--- a/test_launch_ros/test/test_launch_ros/actions/test_lifecycle_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_lifecycle_node.py
@@ -1,0 +1,57 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the LifecycleNode Action."""
+
+from launch import LaunchContext
+from launch_ros.actions import LifecycleNode
+
+import pytest
+
+
+def test_lifecycle_node_constructor():
+    # Construction without name
+    with pytest.raises(TypeError):
+        LifecycleNode(
+            package='asd',
+            executable='bsd',
+            name='my_node',
+        )
+    # Construction without namespace
+    # TODO(ivanpauno): This should raise TypeError.
+    with pytest.raises(RuntimeError):
+        LifecycleNode(
+            package='asd',
+            executable='bsd',
+            namespace='my_ns',
+        )
+    # Successfull construction
+    LifecycleNode(
+        package='asd',
+        executable='bsd',
+        name='my_node',
+        namespace='my_ns',
+    )
+
+
+def test_node_name():
+    node_object = LifecycleNode(
+        package='asd',
+        executable='bsd',
+        name='my_node',
+        namespace='my_ns',
+    )
+    lc = LaunchContext()
+    node_object._perform_substitutions(lc)
+    assert node_object.is_node_name_fully_specified() is True

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -19,6 +19,7 @@ import pathlib
 import unittest
 import warnings
 
+from launch import LaunchContext
 from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import Shutdown
@@ -299,24 +300,25 @@ class TestNode(unittest.TestCase):
                 },
             }])
 
+
 def test_node_name():
     node_without_ns = launch_ros.actions.Node(
         package='asd',
         executable='bsd',
         name='my_node',
     )
-    lc = launch.LaunchContext()
-    node_without_ns._perform_substitutions(context)
-    assert not node.is_node_name_fully_specified()
+    lc = LaunchContext()
+    node_without_ns._perform_substitutions(lc)
+    assert not node_without_ns.is_node_name_fully_specified()
 
     node_without_name = launch_ros.actions.Node(
         package='asd',
         executable='bsd',
         namespace='my_ns',
     )
-    lc = launch.LaunchContext()
-    node_without_ns._perform_substitutions(context)
-    assert not node.is_node_name_fully_specified()
+    lc = LaunchContext()
+    node_without_name._perform_substitutions(lc)
+    assert not node_without_name.is_node_name_fully_specified()
 
     node_with_fqn = launch_ros.actions.Node(
         package='asd',
@@ -324,6 +326,6 @@ def test_node_name():
         name='my_node',
         namespace='my_ns',
     )
-    lc = launch.LaunchContext()
-    node_without_ns._perform_substitutions(context)
-    assert node.is_node_name_fully_specified()
+    lc = LaunchContext()
+    node_with_fqn._perform_substitutions(lc)
+    assert node_with_fqn.is_node_name_fully_specified()

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -44,8 +44,6 @@ class TestNode(unittest.TestCase):
     def _create_node(self, *, parameters=None, remappings=None):
         return launch_ros.actions.Node(
             package='demo_nodes_py', executable='talker_qos', output='screen',
-            # The node name is required for parameter dicts.
-            # See https://github.com/ros2/launch/issues/139.
             name='my_node', namespace='my_ns',
             exec_name='my_node_process',
             arguments=['--number_of_cycles', '1'],
@@ -300,3 +298,32 @@ class TestNode(unittest.TestCase):
                     },
                 },
             }])
+
+def test_node_name():
+    node_without_ns = launch_ros.actions.Node(
+        package='asd',
+        executable='bsd',
+        name='my_node',
+    )
+    lc = launch.LaunchContext()
+    node_without_ns._perform_substitutions(context)
+    assert not node.is_node_name_fully_specified()
+
+    node_without_name = launch_ros.actions.Node(
+        package='asd',
+        executable='bsd',
+        namespace='my_ns',
+    )
+    lc = launch.LaunchContext()
+    node_without_ns._perform_substitutions(context)
+    assert not node.is_node_name_fully_specified()
+
+    node_with_fqn = launch_ros.actions.Node(
+        package='asd',
+        executable='bsd',
+        name='my_node',
+        namespace='my_ns',
+    )
+    lc = launch.LaunchContext()
+    node_without_ns._perform_substitutions(context)
+    assert node.is_node_name_fully_specified()

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -25,10 +25,9 @@ from launch import LaunchService
 from launch.actions import Shutdown
 from launch.substitutions import EnvironmentVariable
 import launch_ros.actions.node
-import launch_ros.actions.lifecycle_node
+import pytest
 import yaml
 
-import pytest
 
 class TestNode(unittest.TestCase):
 
@@ -305,60 +304,39 @@ class TestNode(unittest.TestCase):
 
 def get_test_node_name_parameters():
     return [
-        pytest.param((
+        pytest.param(
             launch_ros.actions.Node(
                 package='asd',
                 executable='bsd',
                 name='my_node',
-            ), False),
-            id="Node without namespace"
+            ),
+            False,
+            id='Node without namespace'
         ),
-        pytest.param((
+        pytest.param(
             launch_ros.actions.Node(
                 package='asd',
                 executable='bsd',
                 namespace='my_ns',
-            ), False),
-            id="Node without name"
+            ),
+            False,
+            id='Node without name'
         ),
-        pytest.param((
+        pytest.param(
             launch_ros.actions.Node(
                 package='asd',
                 executable='bsd',
                 name='my_node',
                 namespace='my_ns',
-            ), True),
-            id="Node with fully qualified name"
-        ),
-        pytest.param((
-            launch_ros.actions.LifecycleNode(
-                package='asd',
-                executable='bsd',
-                name='my_node',
-            ), False),
-            id="LifecycleNode without namespace"
-        ),
-        pytest.param((
-            launch_ros.actions.LifecycleNode(
-                package='asd',
-                executable='bsd',
-                namespace='my_ns',
-            ), False),
-            id="LifecycleNode without name"
-        ),
-        pytest.param((
-            launch_ros.actions.LifecycleNode(
-                package='asd',
-                executable='bsd',
-                name='my_node',
-                namespace='my_ns',
-            ), True),
-            id="LifecycleNode with fully qualified name"
+            ),
+            True,
+            id='Node with fully qualified name'
         ),
     ]
 
+
 @pytest.mark.parametrize(
-    "node_object",
+    'node_object, expected_result',
     get_test_node_name_parameters()
 )
 def test_node_name(node_object, expected_result):


### PR DESCRIPTION
https://github.com/ros2/launch_ros/pull/153 introduced some regressions in nightlies:

https://ci.ros2.org/view/nightly/job/nightly_linux_release/1582/testReport/junit/(root)/projectroot/test_test_lifecycle_py/
https://ci.ros2.org/view/nightly/job/nightly_linux_release/1582/testReport/junit/lifecycle/TestLifecyclePubSub/test_talker_lifecycle/
https://ci.ros2.org/view/nightly/job/nightly_linux_release/1582/testReport/junit/lifecycle/TestLifecyclePubSubAfterShutdown/test_talker_graceful_shutdown/

The problem isn't #153 IMO.
The problem is that we were assuming that the node fqn name is known, even when we were not passing a `__ns` remapping rule (if the executable used a namespace different to `/` and a namespace wasn't being passed explicitly, LifecycleNode action was already broken).

There are two options:
- Make namespace argument required.
- Default to `/` (overriding whatever was specified in the executable).

I prefer the first option.
This is implementing the second option, as the first requires multiple PRs in other repos.