### PR TITLE
Add a SetParameter action that sets a parameter to all nodes in the same scope

### DIFF
--- a/launch_ros/launch_ros/actions/__init__.py
+++ b/launch_ros/launch_ros/actions/__init__.py
@@ -19,6 +19,7 @@ from .lifecycle_node import LifecycleNode
 from .load_composable_nodes import LoadComposableNodes
 from .node import Node
 from .push_ros_namespace import PushRosNamespace
+from .set_parameter import SetParameter
 
 __all__ = [
     'ComposableNodeContainer',
@@ -26,4 +27,5 @@ __all__ = [
     'LoadComposableNodes',
     'Node',
     'PushRosNamespace',
+    'SetParameter',
 ]

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -202,10 +202,12 @@ def get_composable_node_load_request(
                 perform_substitutions(context, list(to)),
             ))
     global_params = context.launch_configurations.get('ros_params', None)
-    parameters = composable_node_description.parameters
+    parameters = []
     if global_params is not None:
-        parameters = (normalize_parameter_dict(global_params), *parameters)
+        parameters.append(normalize_parameter_dict(global_params))
     if composable_node_description.parameters is not None:
+        parameters.extend(list(composable_node_description.parameters))
+    if parameters:
         request.parameters = [
             param.to_parameter_msg() for param in to_parameters_list(
                 context, evaluate_parameters(

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -39,6 +39,7 @@ from ..utilities import add_node_name
 from ..utilities import evaluate_parameters
 from ..utilities import get_node_name_count
 from ..utilities import to_parameters_list
+from ..utilities.normalize_parameters import normalize_parameter_dict
 
 
 class LoadComposableNodes(Action):
@@ -96,44 +97,7 @@ class LoadComposableNodes(Action):
                     )
                 )
                 return
-        request = composition_interfaces.srv.LoadNode.Request()
-        request.package_name = perform_substitutions(
-            context, composable_node_description.package
-        )
-        request.plugin_name = perform_substitutions(
-            context, composable_node_description.node_plugin
-        )
-        if composable_node_description.node_name is not None:
-            request.node_name = perform_substitutions(
-                context, composable_node_description.node_name
-            )
-        if composable_node_description.node_namespace is not None:
-            request.node_namespace = perform_substitutions(
-                context, composable_node_description.node_namespace
-            )
-        # request.log_level = perform_substitutions(context, node_description.log_level)
-        if composable_node_description.remappings is not None:
-            for from_, to in composable_node_description.remappings:
-                request.remap_rules.append('{}:={}'.format(
-                    perform_substitutions(context, list(from_)),
-                    perform_substitutions(context, list(to)),
-                ))
-        if composable_node_description.parameters is not None:
-            request.parameters = [
-                param.to_parameter_msg() for param in to_parameters_list(
-                    context, evaluate_parameters(
-                        context, composable_node_description.parameters
-                    )
-                )
-            ]
-        if composable_node_description.extra_arguments is not None:
-            request.extra_arguments = [
-                param.to_parameter_msg() for param in to_parameters_list(
-                    context, evaluate_parameters(
-                        context, composable_node_description.extra_arguments
-                    )
-                )
-            ]
+        request = get_composable_node_load_request(composable_node_description, context)
         response = self.__rclpy_load_node_client.call(request)
         node_name = response.full_node_name if response.full_node_name else request.node_name
         if response.success:
@@ -208,3 +172,53 @@ class LoadComposableNodes(Action):
                 None, self._load_in_sequence, self.__composable_node_descriptions, context
             )
         )
+
+
+def get_composable_node_load_request(
+    composable_node_description: ComposableNode,
+    context: LaunchContext
+):
+    """Get the request that will be send to the composable node container."""
+    request = composition_interfaces.srv.LoadNode.Request()
+    request.package_name = perform_substitutions(
+        context, composable_node_description.package
+    )
+    request.plugin_name = perform_substitutions(
+        context, composable_node_description.node_plugin
+    )
+    if composable_node_description.node_name is not None:
+        request.node_name = perform_substitutions(
+            context, composable_node_description.node_name
+        )
+    if composable_node_description.node_namespace is not None:
+        request.node_namespace = perform_substitutions(
+            context, composable_node_description.node_namespace
+        )
+    # request.log_level = perform_substitutions(context, node_description.log_level)
+    if composable_node_description.remappings is not None:
+        for from_, to in composable_node_description.remappings:
+            request.remap_rules.append('{}:={}'.format(
+                perform_substitutions(context, list(from_)),
+                perform_substitutions(context, list(to)),
+            ))
+    global_params = context.launch_configurations.get('ros_params', None)
+    parameters = composable_node_description.parameters
+    if global_params is not None:
+        parameters = (normalize_parameter_dict(global_params), *parameters)
+    if composable_node_description.parameters is not None:
+        request.parameters = [
+            param.to_parameter_msg() for param in to_parameters_list(
+                context, evaluate_parameters(
+                    context, parameters
+                )
+            )
+        ]
+    if composable_node_description.extra_arguments is not None:
+        request.extra_arguments = [
+            param.to_parameter_msg() for param in to_parameters_list(
+                context, evaluate_parameters(
+                    context, composable_node_description.extra_arguments
+                )
+            )
+        ]
+    return request

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -396,6 +396,7 @@ class Node(ExecuteProcess):
             for i, params in enumerate(evaluated_parameters):
                 if isinstance(params, dict):
                     param_file_path = self._create_params_file_from_dict(params)
+                    assert os.path.isfile(param_file_path)
                 elif isinstance(params, pathlib.Path):
                     param_file_path = str(params)
                 else:

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -192,12 +192,6 @@ class Node(ExecuteProcess):
             ensure_argument_type(parameters, (list), 'parameters', 'Node')
             # All elements in the list are paths to files with parameters (or substitutions that
             # evaluate to paths), or dictionaries of parameters (fields can be substitutions).
-            i = 0
-            for param in parameters:
-                cmd += ['--params-file', LocalSubstitution(
-                    "ros_specific_arguments['params'][{}]".format(i),
-                    description='parameter {}'.format(i))]
-                i += 1
             normalized_params = normalize_parameters(parameters)
         if remappings is not None:
             i = 0
@@ -220,8 +214,8 @@ class Node(ExecuteProcess):
 
         self.__expanded_node_name = self.UNSPECIFIED_NODE_NAME
         self.__expanded_node_namespace = self.UNSPECIFIED_NODE_NAMESPACE
-        self.__final_node_name = None  # type: Optional[Text]
         self.__expanded_parameter_files = None  # type: Optional[List[Text]]
+        self.__final_node_name = None  # type: Optional[Text]
         self.__expanded_remappings = None  # type: Optional[List[Tuple[Text, Text]]]
 
         self.__substitutions_performed = False
@@ -385,11 +379,21 @@ class Node(ExecuteProcess):
         if self.__expanded_node_namespace != '/':
             self.__final_node_name += self.__expanded_node_namespace
         self.__final_node_name += '/' + self.__expanded_node_name
+        # expand global parameters first,
+        # so they can be overriden with specific parameters of this Node
+        global_params = context.launch_configurations.get('ros_params', None)
+        if global_params is not None or self.__parameters is not None:
+            self.__expanded_parameter_files = []
+        if global_params is not None:
+            param_file_path = self._create_params_file_from_dict(global_params)
+            self.__expanded_parameter_files.append(param_file_path)
+            cmd_extension = ['--params-file', f'{param_file_path}']
+            self.cmd.extend([normalize_to_list_of_substitutions(x) for x in cmd_extension])
+            assert os.path.isfile(param_file_path)
         # expand parameters too
         if self.__parameters is not None:
-            self.__expanded_parameter_files = []
             evaluated_parameters = evaluate_parameters(context, self.__parameters)
-            for params in evaluated_parameters:
+            for i, params in enumerate(evaluated_parameters):
                 if isinstance(params, dict):
                     param_file_path = self._create_params_file_from_dict(params)
                 elif isinstance(params, pathlib.Path):
@@ -400,9 +404,10 @@ class Node(ExecuteProcess):
                     self.__logger.warning(
                         'Parameter file path is not a file: {}'.format(param_file_path),
                     )
-                    # Don't skip adding the file to the parameter list since space has been
-                    # reserved for it in the ros_specific_arguments.
+                    continue
                 self.__expanded_parameter_files.append(param_file_path)
+                cmd_extension = ['--params-file', f'{param_file_path}']
+                self.cmd.extend([normalize_to_list_of_substitutions(x) for x in cmd_extension])
         # expand remappings too
         if self.__remappings is not None:
             self.__expanded_remappings = []
@@ -425,8 +430,6 @@ class Node(ExecuteProcess):
             ros_specific_arguments['name'] = '__node:={}'.format(self.__expanded_node_name)
         if self.__expanded_node_namespace != '':
             ros_specific_arguments['ns'] = '__ns:={}'.format(self.__expanded_node_namespace)
-        if self.__expanded_parameter_files is not None:
-            ros_specific_arguments['params'] = self.__expanded_parameter_files
         if self.__expanded_remappings is not None:
             ros_specific_arguments['remaps'] = []
             for remapping_from, remapping_to in self.__expanded_remappings:

--- a/launch_ros/launch_ros/actions/push_ros_namespace.py
+++ b/launch_ros/launch_ros/actions/push_ros_namespace.py
@@ -29,8 +29,7 @@ from launch.utilities import perform_substitutions
 
 from rclpy.validate_namespace import validate_namespace
 
-# TODO(ivanpauno): Generalize launch.frontend so both hyphens and underscores are equivalent.
-@expose_action('push_ros_namespace')
+
 @expose_action('push-ros-namespace')
 class PushRosNamespace(Action):
     """

--- a/launch_ros/launch_ros/actions/push_ros_namespace.py
+++ b/launch_ros/launch_ros/actions/push_ros_namespace.py
@@ -29,7 +29,8 @@ from launch.utilities import perform_substitutions
 
 from rclpy.validate_namespace import validate_namespace
 
-
+# TODO(ivanpauno): Generalize launch.frontend so both hyphens and underscores are equivalent.
+@expose_action('push_ros_namespace')
 @expose_action('push-ros-namespace')
 class PushRosNamespace(Action):
     """
@@ -50,14 +51,14 @@ class PushRosNamespace(Action):
 
     @classmethod
     def parse(cls, entity: Entity, parser: Parser):
-        """Return `SetLaunchConfiguration` action and kwargs for constructing it."""
+        """Return `PushRosNamespace` action and kwargs for constructing it."""
         _, kwargs = super().parse(entity, parser)
         kwargs['namespace'] = parser.parse_substitution(entity.get_attr('namespace'))
         return cls, kwargs
 
     @property
     def namespace(self) -> List[Substitution]:
-        """Getter for self.__name."""
+        """Getter for self.__namespace."""
         return self.__namespace
 
     def execute(self, context: LaunchContext):

--- a/launch_ros/launch_ros/actions/set_paramater.py
+++ b/launch_ros/launch_ros/actions/set_paramater.py
@@ -1,0 +1,92 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the `SetParameter` action."""
+
+from typing import List
+
+from launch import Action
+from launch import Substitution
+from launch.frontend import Entity
+from launch.frontend import expose_action
+from launch.frontend import Parser
+from launch.launch_context import LaunchContext
+from launch.some_substitutions_type import SomeSubstitutionsType
+
+from launch_ros.parameters_type import SomeParameterValue
+from launch_ros.utilities import evaluate_parameter_dict
+from launch_ros.utilities import normalize_parameter_dict
+
+
+# TODO(ivanpauno): Generalize launch.frontend so both hyphens and underscores are equivalent.
+@expose_action('set_parameter')
+@expose_action('set-parameter')
+class SetParameter(Action):
+    """
+    Action that sets a parameter in the current context.
+
+    This parameter will be set in all the nodes launched in the same scope.
+    e.g.:
+    ```python3
+        LaunchDescription([
+            ...,
+            GroupAction(
+                actions = [
+                    ...,
+                    SetParameter(name='my_param', value='2'),
+                    ...,
+                    Node(...),  // the param will be passed to this node
+                    ...,
+                ]
+            ),
+            Node(...),  // here it won't be passed, as it's not in the same scope
+            ...
+        ])
+    ```
+    """
+
+    def __init__(
+        self,
+        name: SomeSubstitutionsType,
+        value: SomeParameterValue,
+        **kwargs
+    ) -> None:
+        """Create a SetParameter action."""
+        super().__init__(**kwargs)
+        self.__param_dict = normalize_parameter_dict({name: value})
+
+    @classmethod
+    def parse(cls, entity: Entity, parser: Parser):
+        """Return `SetParameter` action and kwargs for constructing it."""
+        _, kwargs = super().parse(entity, parser)
+        kwargs['name'] = parser.parse_substitution(entity.get_attr('name'))
+        kwargs['value'] = parser.parse_substitution(entity.get_attr('value'))
+        return cls, kwargs
+
+    @property
+    def name(self) -> List[Substitution]:
+        """Getter for name."""
+        return self.__param_dict.keys()[0]
+
+    @property
+    def value(self) -> List[Substitution]:
+        """Getter for value."""
+        return self.__param_dict.values()[0]
+
+    def execute(self, context: LaunchContext):
+        """Execute the action."""
+        eval_param_dict = evaluate_parameter_dict(context, self.__param_dict)
+        global_params = context.launch_configurations.get('ros_params', {})
+        global_params.update(eval_param_dict)
+        context.launch_configurations['ros_params'] = global_params

--- a/launch_ros/launch_ros/actions/set_parameter.py
+++ b/launch_ros/launch_ros/actions/set_parameter.py
@@ -25,8 +25,8 @@ from launch.launch_context import LaunchContext
 from launch.some_substitutions_type import SomeSubstitutionsType
 
 from launch_ros.parameters_type import SomeParameterValue
-from launch_ros.utilities import evaluate_parameter_dict
-from launch_ros.utilities import normalize_parameter_dict
+from launch_ros.utilities.evaluate_parameters import evaluate_parameter_dict
+from launch_ros.utilities.normalize_parameters import normalize_parameter_dict
 
 
 # TODO(ivanpauno): Generalize launch.frontend so both hyphens and underscores are equivalent.

--- a/launch_ros/launch_ros/actions/set_parameter.py
+++ b/launch_ros/launch_ros/actions/set_parameter.py
@@ -29,9 +29,7 @@ from launch_ros.utilities.evaluate_parameters import evaluate_parameter_dict
 from launch_ros.utilities.normalize_parameters import normalize_parameter_dict
 
 
-# TODO(ivanpauno): Generalize launch.frontend so both hyphens and underscores are equivalent.
 @expose_action('set_parameter')
-@expose_action('set-parameter')
 class SetParameter(Action):
     """
     Action that sets a parameter in the current context.

--- a/launch_ros/launch_ros/utilities/__init__.py
+++ b/launch_ros/launch_ros/utilities/__init__.py
@@ -29,8 +29,10 @@ from .track_node_names import get_node_name_count
 __all__ = [
     'add_node_name',
     'evaluate_parameters',
+    'evaluate_parameters_dict',
     'get_node_name_count',
     'normalize_parameters',
+    'normalize_parameters_dict',
     'normalize_remap_rule',
     'normalize_remap_rules',
     'to_parameters_list',

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -33,13 +33,13 @@ class TestNode(unittest.TestCase):
 
     def _assert_launch_errors(self, actions):
         ld = LaunchDescription(actions)
-        ls = LaunchService()
+        ls = LaunchService(debug=True)
         ls.include_launch_description(ld)
         assert 0 != ls.run()
 
     def _assert_launch_no_errors(self, actions):
         ld = LaunchDescription(actions)
-        ls = LaunchService()
+        ls = LaunchService(debug=True)
         ls.include_launch_description(ld)
         assert 0 == ls.run()
 

--- a/test_launch_ros/test/test_launch_ros/actions/test_set_parameter.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_set_parameter.py
@@ -36,12 +36,12 @@ def get_set_parameter_test_parameters():
     return [
         pytest.param(
             [{'my_param': '2'}],  # to set
-            [{'my_param': '2'}],  # expected
+            {'my_param': '2'},  # expected
             id='One param'
         ),
         pytest.param(
             [{'my_param': '2', 'another_param': '2'}, {'my_param': '3'}],
-            [{'my_param': '3', 'another_param': '2'}],
+            {'my_param': '3', 'another_param': '2'},
             id='Two params, overriding one'
         ),
     ]
@@ -59,7 +59,7 @@ def test_set_param(params_to_set, expected_result):
     lc = MockContext()
     for set_param in set_parameter_actions:
         set_param.execute(lc)
-    lc.launch_configurations == {'ros_params': expected_result}
+    assert lc.launch_configurations == {'ros_params': expected_result}
 
 
 def test_set_param_with_node():
@@ -107,7 +107,6 @@ def test_set_param_with_composable_node():
     set_param_2.execute(lc)
     request = get_composable_node_load_request(node_description, lc)
     parameters = request.parameters
-    print(parameters)
     assert len(parameters) == 3
     assert parameters[0].name == 'my_param'
     assert parameters[0].value.string_value == 'my_value'
@@ -115,3 +114,18 @@ def test_set_param_with_composable_node():
     assert parameters[1].value.string_value == 'csd'
     assert parameters[2].name == 'asd'
     assert parameters[2].value.string_value == 'bsd'
+
+    lc = MockContext()
+    node_description = ComposableNode(
+        package='asd',
+        plugin='my_plugin',
+        name='my_node',
+        namespace='my_ns',
+    )
+    set_param = SetParameter(name='my_param', value='my_value')
+    set_param.execute(lc)
+    request = get_composable_node_load_request(node_description, lc)
+    parameters = request.parameters
+    assert len(parameters) == 1
+    assert parameters[0].name == 'my_param'
+    assert parameters[0].value.string_value == 'my_value'

--- a/test_launch_ros/test/test_launch_ros/actions/test_set_parameter.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_set_parameter.py
@@ -1,0 +1,90 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the SetParameter Action."""
+
+from launch_ros.actions import Node
+from launch_ros.actions import SetParameter
+
+import pytest
+import yaml
+
+
+class MockContext:
+
+    def __init__(self):
+        self.launch_configurations = {}
+
+    def perform_substitution(self, sub):
+        return sub.perform(None)
+
+
+def get_set_parameter_test_parameters():
+    return [
+        pytest.param(
+            [{'my_param': '2'}],  # to set
+            [{'my_param': '2'}],  # expected
+            id='One param'
+        ),
+        pytest.param(
+            [{'my_param': '2', 'another_param': '2'}, {'my_param': '3'}],
+            [{'my_param': '3', 'another_param': '2'}],
+            id='Two params, overriding one'
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    'params_to_set, expected_result',
+    get_set_parameter_test_parameters()
+)
+def test_set_param(params_to_set, expected_result):
+    set_parameter_actions = []
+    for dicts in params_to_set:
+        for name, value in dicts.items():
+            set_parameter_actions.append(SetParameter(name=name, value=value))
+    lc = MockContext()
+    for set_param in set_parameter_actions:
+        set_param.execute(lc)
+    lc.launch_configurations == {'ros_params': expected_result}
+
+
+def test_set_param_with_node():
+    lc = MockContext()
+    node = Node(
+        package='asd',
+        executable='bsd',
+        name='my_node',
+        namespace='my_ns',
+        parameters=[{'asd': 'bsd'}]
+    )
+    set_param = SetParameter(name='my_param', value='my_value')
+    set_param.execute(lc)
+    node._perform_substitutions(lc)
+    expanded_parameter_files = node._Node__expanded_parameter_files
+    assert len(expanded_parameter_files) == 2
+    with open(expanded_parameter_files[0], 'r') as h:
+        expanded_parameters_dict = yaml.load(h, Loader=yaml.FullLoader)
+        assert expanded_parameters_dict == {
+            '/my_ns/my_node': {
+                'ros__parameters': {'my_param': 'my_value'}
+            }
+        }
+    with open(expanded_parameter_files[1], 'r') as h:
+        expanded_parameters_dict = yaml.load(h, Loader=yaml.FullLoader)
+        assert expanded_parameters_dict == {
+            '/my_ns/my_node': {
+                'ros__parameters': {'asd': 'bsd'}
+            }
+        }

--- a/test_launch_ros/test/test_launch_ros/actions/test_set_parameter.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_set_parameter.py
@@ -14,6 +14,10 @@
 
 """Tests for the SetParameter Action."""
 
+from launch import LaunchContext
+from launch.actions import PopLaunchConfigurations
+from launch.actions import PushLaunchConfigurations
+
 from launch_ros.actions import Node
 from launch_ros.actions import SetParameter
 from launch_ros.actions.load_composable_nodes import get_composable_node_load_request
@@ -60,6 +64,19 @@ def test_set_param(params_to_set, expected_result):
     for set_param in set_parameter_actions:
         set_param.execute(lc)
     assert lc.launch_configurations == {'ros_params': expected_result}
+
+
+def test_set_param_is_scoped():
+    lc = LaunchContext()
+    push_conf = PushLaunchConfigurations()
+    pop_conf = PopLaunchConfigurations()
+    set_param = SetParameter(name='my_param', value='my_value')
+
+    push_conf.execute(lc)
+    set_param.execute(lc)
+    assert lc.launch_configurations == {'ros_params': {'my_param': 'my_value'}}
+    pop_conf.execute(lc)
+    assert lc.launch_configurations == {}
 
 
 def test_set_param_with_node():

--- a/test_launch_ros/test/test_launch_ros/actions/test_set_parameter.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_set_parameter.py
@@ -16,6 +16,8 @@
 
 from launch_ros.actions import Node
 from launch_ros.actions import SetParameter
+from launch_ros.actions.load_composable_nodes import get_composable_node_load_request
+from launch_ros.descriptions import ComposableNode
 
 import pytest
 import yaml
@@ -88,3 +90,28 @@ def test_set_param_with_node():
                 'ros__parameters': {'asd': 'bsd'}
             }
         }
+
+
+def test_set_param_with_composable_node():
+    lc = MockContext()
+    node_description = ComposableNode(
+        package='asd',
+        plugin='my_plugin',
+        name='my_node',
+        namespace='my_ns',
+        parameters=[{'asd': 'bsd'}]
+    )
+    set_param_1 = SetParameter(name='my_param', value='my_value')
+    set_param_2 = SetParameter(name='asd', value='csd')
+    set_param_1.execute(lc)
+    set_param_2.execute(lc)
+    request = get_composable_node_load_request(node_description, lc)
+    parameters = request.parameters
+    print(parameters)
+    assert len(parameters) == 3
+    assert parameters[0].name == 'my_param'
+    assert parameters[0].value.string_value == 'my_value'
+    assert parameters[1].name == 'asd'
+    assert parameters[1].value.string_value == 'csd'
+    assert parameters[2].name == 'asd'
+    assert parameters[2].value.string_value == 'bsd'


### PR DESCRIPTION
Similarly to how `PushRosNamespace` action works, this allows a way to set a parameter affecting all `Node` actions and `ComposableNode` descriptions in the same scope.

This partially fixes https://github.com/ros2/launch_ros/issues/45, the other half is doing the same for remapping rules.

This introduces some conflicts with https://github.com/ros2/launch_ros/pull/137, but either way I already have to rebase that PR.