### PR TITLE
Fix case where list of composable nodes is zero

### DIFF
--- a/launch_ros/launch_ros/actions/composable_node_container.py
+++ b/launch_ros/launch_ros/actions/composable_node_container.py
@@ -86,7 +86,10 @@ class ComposableNodeContainer(Node):
         composable nodes load action if it applies.
         """
         load_actions = None  # type: Optional[List[Action]]
-        if self.__composable_node_descriptions is not None:
+        if (
+            self.__composable_node_descriptions is not None and
+            len(self.__composable_node_descriptions) > 0
+        ):
             from .load_composable_nodes import LoadComposableNodes
             # Perform load action once the container has started.
             load_actions = [

--- a/test_launch_ros/test/test_launch_ros/actions/test_composable_node_container.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_composable_node_container.py
@@ -72,6 +72,23 @@ def test_composable_node_container():
     assert get_node_name_count(context, f'/{TEST_NODE_NAMESPACE}/{TEST_NODE_NAME}') == 1
 
 
+def test_composable_node_container_empty_list_of_nodes():
+    """Test launching a ComposableNodeContainer with an empty list of nodes."""
+    actions = [
+        ComposableNodeContainer(
+            package='rclcpp_components',
+            executable='component_container',
+            name=TEST_CONTAINER_NAME,
+            namespace=TEST_CONTAINER_NAMESPACE,
+            composable_node_descriptions=[]
+        ),
+    ]
+
+    context = _assert_launch_no_errors(actions)
+    assert get_node_name_count(context, f'/{TEST_CONTAINER_NAMESPACE}/{TEST_CONTAINER_NAME}') == 1
+    assert get_node_name_count(context, f'/{TEST_NODE_NAMESPACE}/{TEST_NODE_NAME}') == 0
+
+
 def test_composable_node_container_in_group_with_launch_configuration_in_description():
     """
     Test launch configuration is passed to ComposableNode description inside GroupAction.


### PR DESCRIPTION
Otherwise, launch crashes due to an index-out-of-bounds exception.
