### PR TITLE
[Eloquent backport] avoid deprecation warning, use from_parent (#141) Call LaunchROSTestModule with the new API. (#150) 

### DIFF
--- a/launch_testing_ros/launch_testing_ros/pytest/hooks.py
+++ b/launch_testing_ros/launch_testing_ros/pytest/hooks.py
@@ -38,7 +38,7 @@ class LaunchROSTestModule(LaunchTestModule):
 def pytest_launch_collect_makemodule(path, parent, entrypoint):
     marks = getattr(entrypoint, 'pytestmark', [])
     if marks and any(m.name == 'rostest' for m in marks):
-        return LaunchROSTestModule(path, parent)
+        return LaunchROSTestModule.from_parent(parent=parent, fspath=path)
 
 
 def pytest_configure(config):

--- a/launch_testing_ros/launch_testing_ros/pytest/hooks.py
+++ b/launch_testing_ros/launch_testing_ros/pytest/hooks.py
@@ -21,13 +21,18 @@ from ..test_runner import LaunchTestRunner
 class LaunchROSTestItem(LaunchTestItem):
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs, runner_cls=LaunchTestRunner)
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def from_parent(cls, *args, **kwargs):
+        kwargs['runner_cls'] = LaunchTestRunner
+        return super().from_parent(*args, **kwargs)
 
 
 class LaunchROSTestModule(LaunchTestModule):
 
     def makeitem(self, *args, **kwargs):
-        return LaunchROSTestItem(*args, **kwargs)
+        return LaunchROSTestItem.from_parent(*args, **kwargs)
 
 
 def pytest_launch_collect_makemodule(path, parent, entrypoint):


### PR DESCRIPTION
Companion to https://github.com/ros2/launch/pull/459 which is supposed to fix https://github.com/ros2/launch/pull/459

This is a cherry-pick of two PRs: #141 and #150


CI is here: https://github.com/ros2/launch/pull/459#issuecomment-689145079