### PR TITLE
Clean up temporary YAML parameter file

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -450,7 +450,7 @@ class Node(ExecuteProcess):
 
         Delegated to :meth:`launch.actions.ExecuteProcess.execute`.
         """
-        param_file_path, param_file_cleanup = self._perform_substitutions(context)
+        self.param_file_path, self.param_file_cleanup = self._perform_substitutions(context)
         # Prepare the ros_specific_arguments list and add it to the context so that the
         # LocalSubstitution placeholders added to the the cmd can be expanded using the contents.
         ros_specific_arguments: Dict[str, Union[str, List[str]]] = {}
@@ -471,11 +471,6 @@ class Node(ExecuteProcess):
                     'launch context'.format(node_name_count, self.node_name)
                 )
 
-        # Delete temporary parameter yaml file
-        if param_file_cleanup and param_file_path is not None:
-            if os.path.exists(param_file_path):
-                os.remove(param_file_path)
-
         return ret
 
     @property
@@ -487,3 +482,10 @@ class Node(ExecuteProcess):
     def expanded_remapping_rules(self):
         """Getter for expanded_remappings."""
         return self.__expanded_remappings
+
+    def on_exit(self):
+        """Clean up on process termination."""
+        # Delete temporary parameter yaml file
+        if self.param_file_cleanup and self.param_file_path is not None:
+            if os.path.exists(self.param_file_path):
+                os.remove(self.param_file_path)

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -146,7 +146,7 @@ class TestNode(unittest.TestCase):
             assert expanded_parameter_arguments[i] == (str(parameters_file_path), True)
 
     def test_launch_node_with_parameter_descriptions(self):
-        """Test launching a node with parameters specified in a dictionary."""
+        """Test launching a node with parameters specified in a list."""
         os.environ['PARAM1_VALUE'] = 'param1_value'
         os.environ['PARAM2'] = 'param2'
         node_action = self._create_node(
@@ -209,6 +209,7 @@ class TestNode(unittest.TestCase):
                 },
                 'param3': '',
                 'param4': ParameterValue(EnvironmentVariable(name='PARAM4_INT'), value_type=int),
+                '__param_file_cleanup': False,
             }],
         )
         self._assert_launch_no_errors([node_action])
@@ -229,6 +230,7 @@ class TestNode(unittest.TestCase):
                         'param4': 100,
                         'param_group1.list_params': (1.2, 3.4),
                         'param_group1.param_group2.param2_values': ('param2_value',),
+                        '__param_file_cleanup': False,
                     }
                 }
             }


### PR DESCRIPTION
Addresses issue #5 

Opt-out option:
As described in the original issue, the test requires an opt-out option so that it can validate the outputted file.
Not sure if the current way (a `__param_file_cleanup` parameter) is the best way to implement that option. Suggestions of a more proper way?