### PR TITLE
[foxy backport] Fix no specified namespace (#153)

### DIFF
--- a/launch_ros/examples/lifecycle_pub_sub_launch.py
+++ b/launch_ros/examples/lifecycle_pub_sub_launch.py
@@ -36,7 +36,7 @@ def main(argv=sys.argv[1:]):
 
     # Prepare the talker node.
     talker_node = launch_ros.actions.LifecycleNode(
-        node_name='talker',
+        name='talker', namespace='',
         package='lifecycle', executable='lifecycle_talker', output='screen')
 
     # When the talker reaches the 'inactive' state, make it take the 'activate' transition.
@@ -62,7 +62,7 @@ def main(argv=sys.argv[1:]):
                 launch.actions.LogInfo(
                     msg="node 'talker' reached the 'active' state, launching 'listener'."),
                 launch_ros.actions.LifecycleNode(
-                    node_name='listener',
+                    name='listener', namespace='',
                     package='lifecycle', executable='lifecycle_listener', output='screen'),
             ],
         )

--- a/launch_ros/examples/lifecycle_pub_sub_launch.py
+++ b/launch_ros/examples/lifecycle_pub_sub_launch.py
@@ -36,7 +36,7 @@ def main(argv=sys.argv[1:]):
 
     # Prepare the talker node.
     talker_node = launch_ros.actions.LifecycleNode(
-        name='talker', namespace='',
+        name='talker',
         package='lifecycle', executable='lifecycle_talker', output='screen')
 
     # When the talker reaches the 'inactive' state, make it take the 'activate' transition.
@@ -62,7 +62,7 @@ def main(argv=sys.argv[1:]):
                 launch.actions.LogInfo(
                     msg="node 'talker' reached the 'active' state, launching 'listener'."),
                 launch_ros.actions.LifecycleNode(
-                    name='listener', namespace='',
+                    name='listener',
                     package='lifecycle', executable='lifecycle_listener', output='screen'),
             ],
         )

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -19,10 +19,10 @@ import threading
 from typing import cast
 from typing import List
 from typing import Optional
-from typing import Text
 import warnings
 
 import launch
+from launch import SomeSubstitutionsType
 from launch.action import Action
 import launch.logging
 
@@ -42,8 +42,9 @@ class LifecycleNode(Node):
     def __init__(
         self,
         *,
-        name: Optional[Text] = None,
-        node_name: Optional[Text] = None,
+        name: Optional[SomeSubstitutionsType] = None,
+        namespace: SomeSubstitutionsType,
+        node_name: Optional[SomeSubstitutionsType] = None,
         **kwargs
     ) -> None:
         """
@@ -87,7 +88,7 @@ class LifecycleNode(Node):
         # TODO(jacobperron): Remove default value and this check when deprecated API is removed
         if name is None:
             raise RuntimeError("'name' must not be None.'")
-        super().__init__(name=name, **kwargs)
+        super().__init__(name=name, namespace=namespace, **kwargs)
         self.__logger = launch.logging.get_logger(__name__)
         self.__rclpy_subscription = None
         self.__current_state = \

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -43,7 +43,7 @@ class LifecycleNode(Node):
         self,
         *,
         name: Optional[SomeSubstitutionsType] = None,
-        namespace: SomeSubstitutionsType,
+        namespace: SomeSubstitutionsType = '',
         node_name: Optional[SomeSubstitutionsType] = None,
         **kwargs
     ) -> None:

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -43,7 +43,7 @@ class LifecycleNode(Node):
         self,
         *,
         name: Optional[SomeSubstitutionsType] = None,
-        namespace: SomeSubstitutionsType = '',
+        namespace: Optional[SomeSubstitutionsType] = None,
         node_name: Optional[SomeSubstitutionsType] = None,
         **kwargs
     ) -> None:
@@ -76,6 +76,8 @@ class LifecycleNode(Node):
         :param name: The name of the lifecycle node.
           Although it defaults to None it is a required parameter and the default will be removed
           in a future release.
+        :param namespace: Namespace of the node.
+          If no namespace if provided, the global namespace is used.
         :param node_name: (DEPRECATED) The name fo the lifecycle node.
         """
         if node_name is not None:
@@ -88,6 +90,8 @@ class LifecycleNode(Node):
         # TODO(jacobperron): Remove default value and this check when deprecated API is removed
         if name is None:
             raise RuntimeError("'name' must not be None.'")
+        if not namespace:
+            namespace = '/'
         super().__init__(name=name, namespace=namespace, **kwargs)
         self.__logger = launch.logging.get_logger(__name__)
         self.__rclpy_subscription = None

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -348,7 +348,7 @@ class Node(ExecuteProcess):
                 validate_node_name(self.__expanded_node_name)
             self.__expanded_node_name.lstrip('/')
             expanded_node_namespace = None
-            if self.__node_namespace is not None and self.__node_namespace != '':
+            if self.__node_namespace:
                 expanded_node_namespace = perform_substitutions(
                     context, normalize_to_list_of_substitutions(self.__node_namespace))
             base_ns = context.launch_configurations.get('ros_namespace', None)

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -61,15 +61,18 @@ import yaml
 class Node(ExecuteProcess):
     """Action that executes a ROS node."""
 
+    UNSPECIFIED_NODE_NAME = '<node_name_unspecified>'
+    UNSPECIFIED_NODE_NAMESPACE = '<node_namespace_unspecified>'
+
     def __init__(
         self, *,
         executable: Optional[SomeSubstitutionsType] = None,
         node_executable: Optional[SomeSubstitutionsType] = None,
         package: Optional[SomeSubstitutionsType] = None,
         name: Optional[SomeSubstitutionsType] = None,
-        namespace: Optional[SomeSubstitutionsType] = '',
+        namespace: Optional[SomeSubstitutionsType] = None,
         node_name: Optional[SomeSubstitutionsType] = None,
-        node_namespace: SomeSubstitutionsType = '',
+        node_namespace: SomeSubstitutionsType = None,
         exec_name: Optional[SomeSubstitutionsType] = None,
         parameters: Optional[SomeParameters] = None,
         remappings: Optional[SomeRemapRules] = None,
@@ -215,8 +218,8 @@ class Node(ExecuteProcess):
         self.__remappings = [] if remappings is None else remappings
         self.__arguments = arguments
 
-        self.__expanded_node_name = '<node_name_unspecified>'
-        self.__expanded_node_namespace = ''
+        self.__expanded_node_name = self.UNSPECIFIED_NODE_NAME
+        self.__expanded_node_namespace = self.UNSPECIFIED_NODE_NAMESPACE
         self.__final_node_name = None  # type: Optional[Text]
         self.__expanded_parameter_files = None  # type: Optional[List[Text]]
         self.__expanded_remappings = None  # type: Optional[List[Tuple[Text, Text]]]
@@ -321,6 +324,10 @@ class Node(ExecuteProcess):
             raise RuntimeError("cannot access 'node_name' before executing action")
         return self.__final_node_name
 
+    def is_node_name_fully_specified(self):
+        keywords = (self.UNSPECIFIED_NODE_NAME, self.UNSPECIFIED_NODE_NAMESPACE)
+        return all(x not in self.node_name for x in keywords)
+
     def _create_params_file_from_dict(self, params):
         with NamedTemporaryFile(mode='w', prefix='launch_params_', delete=False) as h:
             param_file_path = h.name
@@ -340,19 +347,24 @@ class Node(ExecuteProcess):
                     context, normalize_to_list_of_substitutions(self.__node_name))
                 validate_node_name(self.__expanded_node_name)
             self.__expanded_node_name.lstrip('/')
-            self.__expanded_node_namespace = perform_substitutions(
-                context, normalize_to_list_of_substitutions(self.__node_namespace))
-            if not self.__expanded_node_namespace.startswith('/'):
-                base_ns = context.launch_configurations.get('ros_namespace', '')
-                self.__expanded_node_namespace = (
-                    base_ns + '/' + self.__expanded_node_namespace
-                ).rstrip('/')
-                if (
-                    self.__expanded_node_namespace != '' and not
-                    self.__expanded_node_namespace.startswith('/')
-                ):
-                    self.__expanded_node_namespace = '/' + self.__expanded_node_namespace
-            if self.__expanded_node_namespace != '':
+            expanded_node_namespace = None
+            if self.__node_namespace is not None:
+                expanded_node_namespace = perform_substitutions(
+                    context, normalize_to_list_of_substitutions(self.__node_namespace))
+            base_ns = context.launch_configurations.get('ros_namespace', None)
+            if base_ns is not None or expanded_node_namespace is not None:
+                if expanded_node_namespace is None:
+                    expanded_node_namespace = ''
+                if base_ns is None:
+                    base_ns = ''
+                if not expanded_node_namespace.startswith('/'):
+                    expanded_node_namespace = (
+                        base_ns + '/' + expanded_node_namespace
+                    ).rstrip('/')
+                if not expanded_node_namespace.startswith('/'):
+                    expanded_node_namespace = '/' + expanded_node_namespace
+                self.__expanded_node_namespace = expanded_node_namespace
+            if expanded_node_namespace is not None:
                 cmd_extension = ['-r', LocalSubstitution("ros_specific_arguments['ns']")]
                 self.cmd.extend([normalize_to_list_of_substitutions(x) for x in cmd_extension])
                 validate_namespace(self.__expanded_node_namespace)
@@ -368,7 +380,7 @@ class Node(ExecuteProcess):
             )
             raise
         self.__final_node_name = ''
-        if self.__expanded_node_namespace not in ['', '/']:
+        if self.__expanded_node_namespace != '/':
             self.__final_node_name += self.__expanded_node_namespace
         self.__final_node_name += '/' + self.__expanded_node_name
         # expand parameters too
@@ -423,7 +435,7 @@ class Node(ExecuteProcess):
         context.extend_locals({'ros_specific_arguments': ros_specific_arguments})
         ret = super().execute(context)
 
-        if '<node_name_unspecified>' not in self.node_name:
+        if self.is_node_name_fully_specified():
             add_node_name(context, self.node_name)
             node_name_count = get_node_name_count(context, self.node_name)
             if node_name_count > 1:

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -348,7 +348,7 @@ class Node(ExecuteProcess):
                 validate_node_name(self.__expanded_node_name)
             self.__expanded_node_name.lstrip('/')
             expanded_node_namespace = None
-            if self.__node_namespace is not None:
+            if self.__node_namespace is not None and self.__node_namespace != '':
                 expanded_node_namespace = perform_substitutions(
                     context, normalize_to_list_of_substitutions(self.__node_namespace))
             base_ns = context.launch_configurations.get('ros_namespace', None)

--- a/test_launch_ros/test/test_launch_ros/actions/test_lifecycle_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_lifecycle_node.py
@@ -1,0 +1,57 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the LifecycleNode Action."""
+
+from launch import LaunchContext
+from launch_ros.actions import LifecycleNode
+
+import pytest
+
+
+def test_lifecycle_node_constructor():
+    # Construction without namespace
+    with pytest.raises(TypeError):
+        LifecycleNode(
+            package='asd',
+            executable='bsd',
+            name='my_node',
+        )
+    # Construction without name
+    # TODO(ivanpauno): This should raise TypeError.
+    with pytest.raises(RuntimeError):
+        LifecycleNode(
+            package='asd',
+            executable='bsd',
+            namespace='my_ns',
+        )
+    # Successfull construction
+    LifecycleNode(
+        package='asd',
+        executable='bsd',
+        name='my_node',
+        namespace='my_ns',
+    )
+
+
+def test_node_name():
+    node_object = LifecycleNode(
+        package='asd',
+        executable='bsd',
+        name='my_node',
+        namespace='my_ns',
+    )
+    lc = LaunchContext()
+    node_object._perform_substitutions(lc)
+    assert node_object.is_node_name_fully_specified() is True

--- a/test_launch_ros/test/test_launch_ros/actions/test_lifecycle_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_lifecycle_node.py
@@ -21,13 +21,6 @@ import pytest
 
 
 def test_lifecycle_node_constructor():
-    # Construction without namespace
-    with pytest.raises(TypeError):
-        LifecycleNode(
-            package='asd',
-            executable='bsd',
-            name='my_node',
-        )
     # Construction without name
     # TODO(ivanpauno): This should raise TypeError.
     with pytest.raises(RuntimeError):

--- a/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
@@ -27,11 +27,13 @@ class Config:
     def __init__(
         self,
         *,
-        node_ns='',
+        node_name=None,
+        node_ns=None,
         push_ns=None,
         expected_ns=None,
         second_push_ns=None
     ):
+        self.node_name = node_name
         self.push_ns = push_ns
         self.node_ns = node_ns
         self.expected_ns = expected_ns
@@ -65,8 +67,20 @@ class Config:
         second_push_ns='/absolute_ns',
         node_ns='node_ns',
         expected_ns='/absolute_ns/node_ns'),
+    Config(
+        node_name='my_node',
+        push_ns='relative_ns',
+        second_push_ns='/absolute_ns',
+        node_ns='node_ns',
+        expected_ns='/absolute_ns/node_ns'),
+    Config(
+        node_name='my_node',
+        node_ns='node_ns',
+        expected_ns='/node_ns'),
     Config(),
-    Config(push_ns=''),
+    Config(
+        push_ns='',
+        expected_ns='/'),
 ))
 def test_push_ros_namespace(config):
     lc = LaunchContext()
@@ -80,7 +94,15 @@ def test_push_ros_namespace(config):
         package='dont_care',
         executable='whatever',
         namespace=config.node_ns,
+        name=config.node_name
     )
     node._perform_substitutions(lc)
-    expected_ns = config.expected_ns if config.expected_ns is not None else ''
+    expected_ns = (
+        config.expected_ns if config.expected_ns is not None else Node.UNSPECIFIED_NODE_NAMESPACE
+    )
+    expected_name = (
+        config.node_name if config.node_name is not None else Node.UNSPECIFIED_NODE_NAME
+    )
+    expected_fqn = expected_ns.rstrip('/') + '/' + expected_name
     assert expected_ns == node.expanded_node_namespace
+    assert expected_fqn == node.node_name

--- a/test_launch_ros/test/test_launch_ros/test_track_node_names.py
+++ b/test_launch_ros/test/test_launch_ros/test_track_node_names.py
@@ -93,7 +93,7 @@ def test_launch_node_with_name_without_namespace():
     ld = LaunchDescription([node])
     context = _launch(ld)
     assert get_node_name_count(context, f'{TEST_NODE_NAMESPACE}/{TEST_NODE_NAME}') == 0
-    assert get_node_name_count(context, f'/{TEST_NODE_NAME}') == 1
+    assert get_node_name_count(context, f'/{TEST_NODE_NAME}') == 0
 
 
 def test_launch_composable_node_with_names(pytestconfig):


### PR DESCRIPTION
Backporting #153 and #157 to Foxy.

In order to maintain backwards compatibility, I've kept the `namespace` argument to `LifecycleNode` as optional (f7c5990).

@ivanpauno PTAL, I *think* this is safe to backport, but you should have more context. I want to backport this, since it is a prerequisite for several other fixes I have made related to launching composable nodes.