### PR TITLE
add --secure option to launch with encryption

### DIFF
--- a/launch_ros/package.xml
+++ b/launch_ros/package.xml
@@ -18,6 +18,8 @@
   <depend>rclpy</depend>
   <depend>python3-yaml</depend>
   <depend>composition_interfaces</depend>
+  <depend>nodl_python</depend>
+  <depend>sros2</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros2launch/package.xml
+++ b/ros2launch/package.xml
@@ -18,6 +18,7 @@
   <depend>launch_ros</depend>
   <depend>ros2cli</depend>
   <depend>ros2pkg</depend>
+  <depend>sros2</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/test_launch_ros/package.xml
+++ b/test_launch_ros/package.xml
@@ -24,6 +24,7 @@
   <test_depend>python3-pytest</test_depend>
   <test_depend>python3-yaml</test_depend>
   <test_depend>rclcpp_components</test_depend>
+  <test_depend>sros2</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/test_ros2launch/package.xml
+++ b/test_ros2launch/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model 
+  href="http://download.ros.org/schema/package_format3.xsd" 
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>test_ros2launch</name>
+  <version>0.10.2</version>
+  <description>Tests for ROS2 launch cli</description>
+  <maintainer email="ted.kern@canonical.com">Ted Kern</maintainer>
+  <license>Apache License 2.0</license>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>python3-pytest</test_depend>
+  <test_depend>ros2launch</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/test_ros2launch/package.xml
+++ b/test_ros2launch/package.xml
@@ -15,6 +15,7 @@
   <test_depend>launch_ros</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>ros2launch</test_depend>
+  <test_depend>sros2</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/test_ros2launch/pytest.ini
+++ b/test_ros2launch/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/test_ros2launch/setup.cfg
+++ b/test_ros2launch/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script-dir=$base/lib/test_ros2launch
+[install]
+install-scripts=$base/lib/test_ros2launch

--- a/test_ros2launch/setup.py
+++ b/test_ros2launch/setup.py
@@ -1,0 +1,36 @@
+from setuptools import find_packages
+from setuptools import setup
+
+package_name = 'test_ros2launch'
+
+setup(
+    name=package_name,
+    version='0.10.2',
+    packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/' + package_name, ['package.xml']),
+    ],
+    install_requires=[
+        'setuptools',
+        'launch_ros',
+        'ros2launch',
+    ],
+    zip_safe=True,
+    maintainer='Ted Kern',
+    maintainer_email='ted.kern@canonical.com',
+    download_url='https://github.com/ros2/launch/releases',
+    keywords=['ROS'],
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Topic :: Software Development',
+    ],
+    description='Tests for ROS specific launch cli.',
+    long_description=(
+        'This package provides tests for the ROS specific '
+        'launch cli.'
+    ),
+    license='Apache License, Version 2.0',
+    tests_require=['pytest'],
+)

--- a/test_ros2launch/test/test_copyright.py
+++ b/test_ros2launch/test/test_copyright.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.main import main
+import pytest
+
+
+@pytest.mark.copyright
+@pytest.mark.linter
+def test_copyright():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found errors'

--- a/test_ros2launch/test/test_flake8.py
+++ b/test_ros2launch/test/test_flake8.py
@@ -1,0 +1,25 @@
+# Copyright 2017 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main_with_errors
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc, errors = main_with_errors(argv=[])
+    assert rc == 0, \
+        'Found %d code style errors / warnings:\n' % len(errors) + \
+        '\n'.join(errors)

--- a/test_ros2launch/test/test_pep257.py
+++ b/test_ros2launch/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'

--- a/test_ros2launch/test/test_ros2launch/api/test_api.py
+++ b/test_ros2launch/test/test_ros2launch/api/test_api.py
@@ -1,0 +1,79 @@
+# Copyright 2020 Canonical, Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the launch api."""
+
+import pytest
+
+from ros2launch.api.api import _Keystore
+from ros2launch.api.api import InvalidKeystoreError
+from ros2launch.api.api import NoKeystoreProvidedError
+from ros2launch.api.api import NonexistantKeystoreError
+
+import sros2.keystore
+
+
+@pytest.fixture
+def keystore_path(tmp_path):
+    sros2.keystore.create_keystore(tmp_path)
+    return tmp_path
+
+
+def test__keystore_existing_keystore(keystore_path):
+    res = _Keystore(keystore_path=keystore_path, create_keystore=False)
+    assert sros2.keystore.is_valid_keystore(keystore_path)
+
+    # Test that it doesn't delete a provided keystore when done
+    del res
+    assert sros2.keystore.is_valid_keystore(keystore_path)
+
+
+def test__keystore_valid_path_uninitialized_success(tmp_path):
+    res = _Keystore(keystore_path=tmp_path, create_keystore=True)
+    assert sros2.keystore.is_valid_keystore(tmp_path)
+
+    del res
+    assert sros2.keystore.is_valid_keystore(tmp_path)
+
+
+def test__keystore_valid_path_uninitialized_fail(tmp_path):
+    with pytest.raises(InvalidKeystoreError):
+        _Keystore(keystore_path=tmp_path, create_keystore=False)
+
+
+def test__keystore_valid_path_nonexistant_success(tmp_path):
+    res = _Keystore(keystore_path=tmp_path / 'foo', create_keystore=True)
+    assert sros2.keystore.is_valid_keystore(tmp_path / 'foo')
+
+    del res
+    assert sros2.keystore.is_valid_keystore(tmp_path / 'foo')
+
+
+def test__keystore_valid_path_nonexistant_fail(tmp_path):
+    with pytest.raises(NonexistantKeystoreError):
+        _Keystore(keystore_path=tmp_path / 'foo', create_keystore=False)
+
+
+def test__keystore_transient_success():
+    res = _Keystore(keystore_path=None, create_keystore=True)
+    assert sros2.keystore.is_valid_keystore(res.path)
+
+    # Test than keystore is cleaned up correctly
+    res = res.path
+    assert not res.exists()
+
+
+def test__keystore_transient_failure():
+    with pytest.raises(NoKeystoreProvidedError):
+        _Keystore(keystore_path=None, create_keystore=False)


### PR DESCRIPTION
add implementation of `--secure` flag to have ros2launch handle configuring all launched actions to use secure ros functionality. Currently only handles encryption, access control functionality can be built from this.

Adds two new optional arguments to `ros2 launch`, 
- `--secure [keystore_path]` 
  Enable security. If a keystore path is provided, create and initialize it if necessary and use it. Otherwise generate an ephemeral keystore for this launch invocation only.
- `--no-create-keystore`
  Do not attempt to create/initialize a keystore or create an ephemeral keystore. Require keystore_path to point to an existing keystore.

The launch description is modified with the necessary steps to set environment variables as needed by rcl, and the creation of keys is handled automatically in the `Node` action type by making a best guess of the fully qualified node name using NoDL.

Adds dependencies on
- [NoDL](https://github.com/Arnatious/nodl): launch_ros
- [SROS2](https://github.com/ros2/sros2): launch_ros, ros2launch