### PR TITLE
Handle any substitution types for SetParameter name argument

### DIFF
--- a/launch_ros/launch_ros/actions/set_parameter.py
+++ b/launch_ros/launch_ros/actions/set_parameter.py
@@ -23,6 +23,7 @@ from launch.frontend import expose_action
 from launch.frontend import Parser
 from launch.launch_context import LaunchContext
 from launch.some_substitutions_type import SomeSubstitutionsType
+from launch.utilities import normalize_to_list_of_substitutions
 
 from launch_ros.parameters_type import SomeParameterValue
 from launch_ros.utilities.evaluate_parameters import evaluate_parameter_dict
@@ -62,7 +63,8 @@ class SetParameter(Action):
     ) -> None:
         """Create a SetParameter action."""
         super().__init__(**kwargs)
-        self.__param_dict = normalize_parameter_dict({name: value})
+        normalized_name = normalize_to_list_of_substitutions(name)
+        self.__param_dict = normalize_parameter_dict({tuple(normalized_name): value})
 
     @classmethod
     def parse(cls, entity: Entity, parser: Parser):

--- a/launch_ros/launch_ros/actions/set_parameter.py
+++ b/launch_ros/launch_ros/actions/set_parameter.py
@@ -14,10 +14,7 @@
 
 """Module for the `SetParameter` action."""
 
-from typing import List
-
 from launch import Action
-from launch import Substitution
 from launch.frontend import Entity
 from launch.frontend import expose_action
 from launch.frontend import Parser
@@ -25,6 +22,8 @@ from launch.launch_context import LaunchContext
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.utilities import normalize_to_list_of_substitutions
 
+from launch_ros.parameters_type import ParameterName
+from launch_ros.parameters_type import ParameterValue
 from launch_ros.parameters_type import SomeParameterValue
 from launch_ros.utilities.evaluate_parameters import evaluate_parameter_dict
 from launch_ros.utilities.normalize_parameters import normalize_parameter_dict
@@ -75,12 +74,12 @@ class SetParameter(Action):
         return cls, kwargs
 
     @property
-    def name(self) -> List[Substitution]:
+    def name(self) -> ParameterName:
         """Getter for name."""
         return self.__param_dict.keys()[0]
 
     @property
-    def value(self) -> List[Substitution]:
+    def value(self) -> ParameterValue:
         """Getter for value."""
         return self.__param_dict.values()[0]
 

--- a/test_launch_ros/test/test_launch_ros/actions/test_set_parameter.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_set_parameter.py
@@ -17,11 +17,13 @@
 from launch import LaunchContext
 from launch.actions import PopLaunchConfigurations
 from launch.actions import PushLaunchConfigurations
+from launch.substitutions import TextSubstitution
 
 from launch_ros.actions import Node
 from launch_ros.actions import SetParameter
 from launch_ros.actions.load_composable_nodes import get_composable_node_load_request
 from launch_ros.descriptions import ComposableNode
+from launch_ros.parameter_descriptions import ParameterValue
 
 import pytest
 import yaml
@@ -39,14 +41,34 @@ class MockContext:
 def get_set_parameter_test_parameters():
     return [
         pytest.param(
-            [{'my_param': '2'}],  # to set
+            [('my_param', '2')],  # to set
             {'my_param': '2'},  # expected
             id='One param'
         ),
         pytest.param(
-            [{'my_param': '2', 'another_param': '2'}, {'my_param': '3'}],
+            [('my_param', '2'), ('another_param', '2'), ('my_param', '3')],
             {'my_param': '3', 'another_param': '2'},
             id='Two params, overriding one'
+        ),
+        pytest.param(
+            [(TextSubstitution(text='my_param'), TextSubstitution(text='my_value'))],
+            {'my_param': 'my_value'},
+            id='Substitution types'
+        ),
+        pytest.param(
+            [((TextSubstitution(text='my_param'),), (TextSubstitution(text='my_value'),))],
+            {'my_param': 'my_value'},
+            id='Tuple of substitution types'
+        ),
+        pytest.param(
+            [([TextSubstitution(text='my_param')], [TextSubstitution(text='my_value')])],
+            {'my_param': 'my_value'},
+            id='List of substitution types'
+        ),
+        pytest.param(
+            [('my_param', ParameterValue('my_value'))],
+            {'my_param': 'my_value'},
+            id='ParameterValue type'
         ),
     ]
 
@@ -57,9 +79,8 @@ def get_set_parameter_test_parameters():
 )
 def test_set_param(params_to_set, expected_result):
     set_parameter_actions = []
-    for dicts in params_to_set:
-        for name, value in dicts.items():
-            set_parameter_actions.append(SetParameter(name=name, value=value))
+    for name, value in params_to_set:
+        set_parameter_actions.append(SetParameter(name=name, value=value))
     lc = MockContext()
     for set_param in set_parameter_actions:
         set_param.execute(lc)


### PR DESCRIPTION
This fixes an error when trying to use the SetParameter action in a front-end launch file (04a8a78).
The parsed 'name' attribute is returned a list of substitutions, which cannot be used as a key in a dictionary.

This PR also fixes some type annotations (abff193).