### PR TITLE
[foxy] Assume root namespace if not provided in ComposableNodeContainer

### DIFF
--- a/launch_ros/launch_ros/actions/composable_node_container.py
+++ b/launch_ros/launch_ros/actions/composable_node_container.py
@@ -77,6 +77,8 @@ class ComposableNodeContainer(Node):
                 )
             namespace = node_namespace
 
+        if not namespace:
+            namespace = '/'
         super().__init__(name=name, namespace=namespace, **kwargs)
         self.__composable_node_descriptions = composable_node_descriptions
 


### PR DESCRIPTION
Fixes a regression introduced in #179

Fixes #185.

We apply the same logic in LifecycleNode to maintain backwards compatibility in Foxy.