### PR TITLE
Make name and namespace mandatory in ComposableNodeContainer, remove deprecated alternatives

### DIFF
--- a/launch_ros/launch_ros/actions/composable_node_container.py
+++ b/launch_ros/launch_ros/actions/composable_node_container.py
@@ -16,7 +16,6 @@
 
 from typing import List
 from typing import Optional
-import warnings
 
 from launch.action import Action
 from launch.launch_context import LaunchContext
@@ -33,10 +32,8 @@ class ComposableNodeContainer(Node):
     def __init__(
         self,
         *,
-        name: Optional[SomeSubstitutionsType] = None,
-        namespace: Optional[SomeSubstitutionsType] = None,
-        node_name: Optional[SomeSubstitutionsType] = None,
-        node_namespace: Optional[SomeSubstitutionsType] = None,
+        name: SomeSubstitutionsType,
+        namespace: SomeSubstitutionsType,
         composable_node_descriptions: Optional[List[ComposableNode]] = None,
         **kwargs
     ) -> None:
@@ -46,35 +43,11 @@ class ComposableNodeContainer(Node):
         Most arguments are forwarded to :class:`launch_ros.actions.Node`, so see the documentation
         of that class for further details.
 
-        .. deprecated:: Foxy
-           Parameters `node_name` and `node_namespace` are deprecated.
-           Use `name` and `namespace` instead.
-
         :param: name the name of the node, mandatory for full container node name resolution
         :param: namespace the ROS namespace for this Node, mandatory for full container node
              name resolution
-        :param: node_name (DEPRECATED) the name of the node, mandatory for full container node
-            name resolution
-        :param: node_namespace (DEPRECATED) the ros namespace for this Node, mandatory for full
-            container node name resolution
         :param composable_node_descriptions: optional descriptions of composable nodes to be loaded
         """
-        if node_name is not None:
-            warnings.warn("The parameter 'node_name' is deprecated, use 'name' instead")
-            if name is not None:
-                raise RuntimeError(
-                    "Passing both 'node_name' and 'name' parameters. Only use 'name'."
-                )
-            name = node_name
-        if node_namespace is not None:
-            warnings.warn("The parameter 'node_namespace' is deprecated, use 'namespace' instead")
-            if namespace is not None:
-                raise RuntimeError(
-                    "Passing both 'node_namespace' and 'namespace' parameters. "
-                    "Only use 'namespace'."
-                )
-            namespace = node_namespace
-
         super().__init__(name=name, namespace=namespace, **kwargs)
         self.__composable_node_descriptions = composable_node_descriptions
 


### PR DESCRIPTION
Based on discussion in https://github.com/ros2/launch_ros/issues/185, the name and namespace are mandatory.

I think that the intention was to check that, but it was overlooked when adding support for the deprecated name of the argument.
This delete the deprecated name (they were deprecated before Foxy release), and now it's checked.