### PR TITLE
[foxy] Improve error message if ComposableNodeContainer 'name' or 'namespace' arg is None

### DIFF
--- a/launch_ros/launch_ros/actions/composable_node_container.py
+++ b/launch_ros/launch_ros/actions/composable_node_container.py
@@ -77,6 +77,10 @@ class ComposableNodeContainer(Node):
                 )
             namespace = node_namespace
 
+
+        if name is None:
+            raise RuntimeError("'name' is a required argument")
+
         if namespace is None:
             raise RuntimeError("'namespace' is a required argument")
 

--- a/launch_ros/launch_ros/actions/composable_node_container.py
+++ b/launch_ros/launch_ros/actions/composable_node_container.py
@@ -77,7 +77,10 @@ class ComposableNodeContainer(Node):
                 )
             namespace = node_namespace
 
-        if not namespace:
+        if namespace is None:
+            raise RuntimeError("'namespace' is a required argument")
+
+        if namespace == '':
             namespace = '/'
         super().__init__(name=name, namespace=namespace, **kwargs)
         self.__composable_node_descriptions = composable_node_descriptions

--- a/launch_ros/launch_ros/actions/composable_node_container.py
+++ b/launch_ros/launch_ros/actions/composable_node_container.py
@@ -77,7 +77,6 @@ class ComposableNodeContainer(Node):
                 )
             namespace = node_namespace
 
-
         if name is None:
             raise RuntimeError("'name' is a required argument")
 


### PR DESCRIPTION
This restores the original behavior in Eloquent and Foxy, but with an improved error message.

The error was accidentally removed in #186.