### PR TITLE
Increase test_composable_node_container timeout

### DIFF
--- a/test_launch_ros/test/test_launch_ros/actions/test_composable_node_container.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_composable_node_container.py
@@ -33,7 +33,7 @@ TEST_NODE_NAME = 'test_composable_node_name'
 TEST_NODE_NAMESPACE = 'test_composable_node_namespace'
 
 
-def _assert_launch_no_errors(actions, *, timeout_sec=1):
+def _assert_launch_no_errors(actions, *, timeout_sec=5):
     ld = LaunchDescription(actions)
     ls = LaunchService(debug=True)
     ls.include_launch_description(ld)


### PR DESCRIPTION
Resolves #184.

With some RMW implementations, like rmw_connext_cpp, it takes a bit longer to start ROS nodes.