### PR TITLE
Node.__init__() executable and ComposableNode.__init__() plugin arguments aren't optional

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -69,7 +69,7 @@ class Node(ExecuteProcess):
 
     def __init__(
         self, *,
-        executable: Optional[SomeSubstitutionsType] = None,
+        executable: SomeSubstitutionsType,
         package: Optional[SomeSubstitutionsType] = None,
         name: Optional[SomeSubstitutionsType] = None,
         namespace: Optional[SomeSubstitutionsType] = None,

--- a/launch_ros/launch_ros/descriptions/composable_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_node.py
@@ -35,7 +35,7 @@ class ComposableNode:
     def __init__(
         self, *,
         package: SomeSubstitutionsType,
-        plugin: Optional[SomeSubstitutionsType] = None,
+        plugin: SomeSubstitutionsType,
         name: Optional[SomeSubstitutionsType] = None,
         namespace: Optional[SomeSubstitutionsType] = None,
         parameters: Optional[SomeParameters] = None,


### PR DESCRIPTION
Fix error introduced in https://github.com/ros2/launch_ros/pull/190.