### PR TITLE
[dashing] Use yaml.safe_load

### DIFF
--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -160,7 +160,7 @@ class TestNode(unittest.TestCase):
         expanded_parameter_files = node_action._Node__expanded_parameter_files
         assert len(expanded_parameter_files) == 1
         with open(expanded_parameter_files[0], 'r') as h:
-            expanded_parameters_dict = yaml.load(h)
+            expanded_parameters_dict = yaml.safe_load(h)
             assert expanded_parameters_dict == {
                 '/**': {
                     'ros__parameters': {


### PR DESCRIPTION
This is a kind of backport of #175. Though #175 doesn't apply due to significant changes to the test code since Dashing, I think the idea is the same.