### PR TITLE
Support non-interactive ros2 launch executions

### DIFF
--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -140,9 +140,18 @@ def parse_launch_arguments(launch_arguments: List[Text]) -> List[Tuple[Text, Tex
     return parsed_launch_arguments.items()
 
 
-def launch_a_launch_file(*, launch_file_path, launch_file_arguments, debug=False):
+def launch_a_launch_file(
+    *,
+    launch_file_path,
+    launch_file_arguments,
+    noninteractive=False,
+    debug=False
+):
     """Launch a given launch file (by path) and pass it the given launch file arguments."""
-    launch_service = launch.LaunchService(argv=launch_file_arguments, debug=debug)
+    launch_service = launch.LaunchService(
+        argv=launch_file_arguments,
+        noninteractive=noninteractive,
+        debug=debug)
     parsed_launch_arguments = parse_launch_arguments(launch_file_arguments)
     # Include the user provided launch file using IncludeLaunchDescription so that the
     # location of the current launch file is set.

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import sys
 
 from ament_index_python.packages import get_package_prefix
 from ament_index_python.packages import PackageNotFoundError
@@ -72,6 +73,9 @@ class LaunchCommand(CommandExtension):
 
     def add_arguments(self, parser, cli_name):
         """Add arguments to argparse."""
+        parser.add_argument(
+            '-n', '--noninteractive', default=not sys.stdin.isatty(), action='store_true',
+            help='Run the launch system non-interactively, with no terminal associated')
         parser.add_argument(
             '-d', '--debug', default=False, action='store_true',
             help='Put the launch system in debug mode, provides more verbose output.')
@@ -155,5 +159,6 @@ class LaunchCommand(CommandExtension):
             return launch_a_launch_file(
                 launch_file_path=path,
                 launch_file_arguments=launch_arguments,
+                noninteractive=args.noninteractive,
                 debug=args.debug
             )


### PR DESCRIPTION
Connected to https://github.com/ros2/launch/pull/475. This patch allows the user to execute `ros2 launch` in non-interactive mode. 