### PR TITLE
Re-order shutdown vs node destruction

### DIFF
--- a/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
@@ -76,8 +76,8 @@ class MockComponentContainer(rclpy.node.Node):
 
     def shutdown(self):
         self._executor.shutdown()
-        self.destroy_node()
         rclpy.shutdown(context=self._context)
+        self.destroy_node()
         self._thread.join()
 
 


### PR DESCRIPTION
I'm not sure if calling Node.destroy_node() while another thread is spinning was ever supported, but it definitely causes problems.

This PR works around the issue, which I opened ros2/rclpy#663 to track.

From what I can tell, `rmw_fastrtps_cpp` generated an exception when this happens, but `rmw_cyclonedds_cpp` is causing a segfault.

Without this change:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13437)](http://ci.ros2.org/job/ci_linux/13437/)

With this change:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13438)](http://ci.ros2.org/job/ci_linux/13438/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8350)](http://ci.ros2.org/job/ci_linux-aarch64/8350/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11158)](http://ci.ros2.org/job/ci_osx/11158/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13493)](http://ci.ros2.org/job/ci_windows/13493/)