### PR TITLE
Fix namespace with LifecycleNode

### DIFF
--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -91,7 +91,7 @@ class LifecycleNode(Node):
         if name is None:
             raise RuntimeError("'name' must not be None.'")
         if not namespace:
-            namespace = '/'
+            namespace = ''
         super().__init__(name=name, namespace=namespace, **kwargs)
         self.__logger = launch.logging.get_logger(__name__)
         self.__rclpy_subscription = None

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -337,7 +337,7 @@ class Node(ExecuteProcess):
                 validate_node_name(self.__expanded_node_name)
             self.__expanded_node_name.lstrip('/')
             expanded_node_namespace: Optional[Text] = None
-            if self.__node_namespace:
+            if self.__node_namespace is not None:
                 expanded_node_namespace = perform_substitutions(
                     context, normalize_to_list_of_substitutions(self.__node_namespace))
             base_ns = context.launch_configurations.get('ros_namespace', None)


### PR DESCRIPTION
Fixes #220.
Regression since #179.

The expectation prior to #179 was that providing no namespace argument
to LifecycleNode would result in an empty, relative namespace.
This change fixes the code to meet that expectation.