### PR TITLE
Add a package marker to test_launch_ros.

### DIFF
--- a/test_launch_ros/setup.py
+++ b/test_launch_ros/setup.py
@@ -16,6 +16,8 @@ setup(
     zip_safe=True,
     data_files=[
         ('share/' + package_name, ['package.xml']),
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
     ],
     author='William Woodall',
     author_email='william@osrfoundation.org',


### PR DESCRIPTION
This quiets the warning from colcon about it not explicitly
installing a marker.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>