### PR TITLE
Use underscores in setup.cfg instead of dashes.

### DIFF
--- a/launch_testing_ros/setup.cfg
+++ b/launch_testing_ros/setup.cfg
@@ -3,6 +3,6 @@
 source = .
 omit = setup.py
 [develop]
-script-dir=$base/lib/launch_testing_ros
+script_dir=$base/lib/launch_testing_ros
 [install]
-install-scripts=$base/lib/launch_testing_ros
+install_scripts=$base/lib/launch_testing_ros


### PR DESCRIPTION
Silences this build time warning:

```
lib/python3.8/site-packages/setuptools/dist.py:642: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead
```