### PR TITLE
Support Python 3.8 importlib.metadata, declare dependency

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -25,7 +25,10 @@ from typing import Text  # noqa: F401
 from typing import Tuple  # noqa: F401
 from typing import Union
 
-import importlib_metadata
+try:
+    import importlib.metadata as importlib_metadata
+except ModuleNotFoundError:
+    import importlib_metadata
 
 from launch.action import Action
 from launch.actions import ExecuteProcess

--- a/launch_ros/package.xml
+++ b/launch_ros/package.xml
@@ -16,6 +16,7 @@
   <depend>lifecycle_msgs</depend>
   <depend>osrf_pycommon</depend>
   <depend>rclpy</depend>
+  <depend>python3-importlib-metadata</depend>
   <depend>python3-yaml</depend>
   <depend>composition_interfaces</depend>
 


### PR DESCRIPTION
The `importlib_metadata` package is a backport of the `importlib.metadata` module from Python 3.8. We should prefer the one coming from Python itself, and fall back to the backport if Python doesn't provide it.

Since this could mean an additional dependency on some platforms, we should also declare that dependency.

This change is required on Fedora 33, which has Python 3.9 and no longer carries the `importlib_metadata` package.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14335)](http://ci.ros2.org/job/ci_linux/14335/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9119)](http://ci.ros2.org/job/ci_linux-aarch64/9119/)
* Linux-rhel [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=123)](https://ci.ros2.org/job/ci_linux-rhel/123/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12018)](http://ci.ros2.org/job/ci_osx/12018/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14437)](http://ci.ros2.org/job/ci_windows/14437/)