### PR TITLE
Simplify logic to fix absolute paths

### DIFF
--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -114,18 +114,11 @@ class LaunchCommand(CommandExtension):
 
     def main(self, *, parser, args):
         """Entry point for CLI program."""
-        mode = 'pkg file'
-        if args.launch_file_name is None:
-            # If only one argument passed, use single file mode.
-            mode = 'single file'
-        else:
-            # Test if first argument is a package, and if not change to single
-            # file mode, but only if the file exists.
-            try:
-                get_package_prefix(args.package_name)
-            except PackageNotFoundError:
-                if os.path.exists(args.package_name):
-                    mode = 'single file'
+        mode = 'single file'
+        # Test if first argument is a file, and if not change to pkg
+        # file mode.
+        if not os.path.isfile(args.package_name):
+            mode = 'pkg file'
 
         path = None
         launch_arguments = []

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -15,7 +15,6 @@
 import os
 import sys
 
-from ament_index_python.packages import get_package_prefix
 from ament_index_python.packages import PackageNotFoundError
 try:
     from argcomplete.completers import FilesCompleter


### PR DESCRIPTION
Simplifies the logic to fix behaviour for absolute paths.

Fixes #221 

There is a caveat for the `'pkg file'` form: if a _file_ with the same name as the target package exists in the current working directory, this will attempt to open that file as a launch file. This breaks from existing behaviour but should be a rare occurrence.