### PR TITLE
fix bug in warning when an entry point fails to load

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -549,7 +549,7 @@ def get_extensions(logger):
         try:
             extension_type = entry_points[entry_point].load()
         except Exception as e:  # noqa: F841
-            logger.warning(f"Failed to load entry point '{entry_point.name}': {e}")
+            logger.warning(f"Failed to load entry point '{entry_points[entry_point].name}': {e}")
             continue
         extension_types[entry_points[entry_point].name] = extension_type
 


### PR DESCRIPTION
It would result in an issue like this:

```
$ ros2 launch demo_nodes_cpp talker_listener.launch.xml
[INFO] [launch]: All log files can be found below /home/william/.ros/log/2021-06-01-11-54-54-320321-ubuntu-1559336
[INFO] [launch]: Default logging verbosity is set to INFO
Task exception was never retrieved
future: <Task finished name='Task-2' coro=<LaunchService._process_one_event() done, defined at /opt/ros/rolling/lib/python3.8/site-packages/launch/launch_service.py:226> exception=InvalidLaunchFileError('xml')>
Traceback (most recent call last):
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch_ros/actions/node.py", line 545, in get_extensions
    extension_type = entry_points[entry_point].load()
  File "/usr/lib/python3.8/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/william/ros2launch_security_ws/build/ros2launch_security/ros2launch_security/node_action/__init__.py", line 16, in <module>
    from . import security
  File "/home/william/ros2launch_security_ws/build/ros2launch_security/ros2launch_security/node_action/security.py", line 26, in <module>
    import nodl
ModuleNotFoundError: No module named 'nodl'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/launch_description_sources/any_launch_file_utilities.py", line 53, in get_launch_description_from_any_launch_file
    return loader(launch_file_path)
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/launch_description_sources/frontend_launch_file_utilities.py", line 35, in get_launch_description_from_frontend_launch_file
    return parser.parse_description(root_entity)
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/frontend/parser.py", line 111, in parse_description
    actions = [self.parse_action(child) for child in entity.children]
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/frontend/parser.py", line 111, in <listcomp>
    actions = [self.parse_action(child) for child in entity.children]
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/frontend/parser.py", line 88, in parse_action
    return instantiate_action(entity, self)
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/frontend/expose.py", line 40, in instantiate_action
    return action_type(**kwargs)
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch_ros/actions/node.py", line 228, in __init__
    self.__extensions = get_extensions(self.__logger)
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch_ros/actions/node.py", line 547, in get_extensions
    logger.warning(f"Failed to load entry point '{entry_point.name}': {e}")
AttributeError: 'str' object has no attribute 'name'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/launch_service.py", line 228, in _process_one_event
    await self.__process_event(next_event)
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/launch_service.py", line 248, in __process_event
    visit_all_entities_and_collect_futures(entity, self.__context))
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 45, in visit_all_entities_and_collect_futures
    futures_to_return += visit_all_entities_and_collect_futures(sub_entity, context)
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 45, in visit_all_entities_and_collect_futures
    futures_to_return += visit_all_entities_and_collect_futures(sub_entity, context)
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 38, in visit_all_entities_and_collect_futures
    sub_entities = entity.visit(context)
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/action.py", line 108, in visit
    return self.execute(context)
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/actions/include_launch_description.py", line 127, in execute
    launch_description = self.__launch_description_source.get_launch_description(context)
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/launch_description_source.py", line 84, in get_launch_description
    self._get_launch_description(self.__expanded_location)
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/launch_description_sources/any_launch_description_source.py", line 53, in _get_launch_description
    return get_launch_description_from_any_launch_file(location)
  File "/opt/ros/rolling/lib/python3.8/site-packages/launch/launch_description_sources/any_launch_file_utilities.py", line 56, in get_launch_description_from_any_launch_file
    raise InvalidLaunchFileError(extension, likely_errors=exceptions)
launch.invalid_launch_file_error.InvalidLaunchFileError: Caught exception when trying to load file of format [xml]: 'str' object has no attribute 'name'
```