### PR TITLE
Add `push_ros_namespace` alias to `push-ros-namespace`

### DIFF
--- a/launch_ros/launch_ros/actions/push_ros_namespace.py
+++ b/launch_ros/launch_ros/actions/push_ros_namespace.py
@@ -33,6 +33,7 @@ from launch_ros.utilities import prefix_namespace
 from rclpy.validate_namespace import validate_namespace
 
 
+@expose_action('push_ros_namespace')
 @expose_action('push-ros-namespace')
 class PushRosNamespace(Action):
     """

--- a/test_launch_ros/test/test_launch_ros/frontend/test_push_ros_namespace_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_push_ros_namespace_frontend.py
@@ -31,6 +31,16 @@ def test_launch_namespace_yaml():
     with io.StringIO(yaml_file) as f:
         check_launch_namespace(f)
 
+    yaml_file_alias = textwrap.dedent(
+        r"""
+        launch:
+           - push_ros_namespace:
+               namespace: 'asd'
+        """
+    )
+    with io.StringIO(yaml_file_alias) as f:
+        check_launch_namespace(f)
+
 
 def test_launch_namespace_xml():
     xml_file = textwrap.dedent(
@@ -41,6 +51,16 @@ def test_launch_namespace_xml():
         """
     )
     with io.StringIO(xml_file) as f:
+        check_launch_namespace(f)
+
+    xml_file_alias = textwrap.dedent(
+        r"""
+        <launch>
+            <push_ros_namespace namespace="asd"/>
+        </launch>
+        """
+    )
+    with io.StringIO(xml_file_alias) as f:
         check_launch_namespace(f)
 
 


### PR DESCRIPTION
Closes #142

Once this is approved, I will update the documentation to use the alias with the underscores (https://github.com/ros2/ros2_documentation/pull/539/files#r409568794).

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>