### PR TITLE
Add `.launch` as an extension for launch files auto-completion

### DIFF
--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -85,6 +85,7 @@ is_launch_file.extensions = [
     'launch.' + extension for extension in Parser.get_available_extensions()
 ]
 is_launch_file.extensions.append('launch.py')
+is_launch_file.extensions.append('.launch')
 is_launch_file.extensions = tuple(is_launch_file.extensions)
 
 


### PR DESCRIPTION
Closes #149

This makes `ros2 launch pkg <tab>` auto-completion include files ending with `.launch` as well.

I looked into adding a test for this, but there are currently none for auto-completion (that I could find). Let me know if I should add one.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>