### PR TITLE
Properly support ros_args attribute through launch frontends

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -310,6 +310,9 @@ class Node(ExecuteProcess):
         args = entity.get_attr('args', optional=True)
         if args is not None:
             kwargs['arguments'] = super()._parse_cmdline(args, parser)
+        ros_args = entity.get_attr('ros_args', optional=True)
+        if ros_args is not None:
+            kwargs['ros_arguments'] = super()._parse_cmdline(ros_args, parser)
         node_name = entity.get_attr('node-name', optional=True)
         if node_name is not None:
             kwargs['node_name'] = parser.parse_substitution(node_name)

--- a/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
@@ -37,7 +37,7 @@ def test_launch_frontend_xml():
             <let name="a_string" value="\'[2, 5, 8]\'"/>
             <let name="a_list" value="[2, 5, 8]"/>
             <let name="my_value" value="100"/>
-            <node pkg="demo_nodes_py" exec="talker_qos" output="screen" name="my_talker" namespace="my_ns" exec_name="my_talker_process" args="--number_of_cycles 1">
+            <node pkg="demo_nodes_py" exec="talker_qos" output="screen" name="my_talker" namespace="my_ns" exec_name="my_talker_process" args="--number_of_cycles 1" ros_args="--log-level info">
                 <param name="param1" value="ads"/>
                 <param name="param_group1">
                     <param name="param_group2">
@@ -91,6 +91,7 @@ def test_launch_frontend_yaml():
                 namespace: my_ns
                 exec_name: my_talker_process
                 args: '--number_of_cycles 1'
+                ros_args: '--log-level info'
                 param:
                     -   name: param1
                         value: ads
@@ -202,6 +203,10 @@ def check_launch_node(file):
     remappings = ld.describe_sub_entities()[3]._Node__remappings
     assert remappings is not None
     assert len(remappings) == 2
+
+    talker_node_action = ld.describe_sub_entities()[3]
+    talker_node_cmd_string = ' '.join(talker_node_action.process_details['cmd'])
+    assert '--ros-args --log-level info' in talker_node_cmd_string
 
     listener_node_action = ld.describe_sub_entities()[4]
     listener_node_cmd = listener_node_action.process_details['cmd']


### PR DESCRIPTION
Follow-up to #249

This actually adds support for a `ros_args` attribute instead of only supporting `ros_arguments` through the `Node` action constructor.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>