### PR TITLE
Resolves #37 - Added --launch-prefix argument for 'ros2 launch' command

### DIFF
--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -152,10 +152,17 @@ def launch_a_launch_file(
     """Launch a given launch file (by path) and pass it the given launch file arguments."""
     for name in sorted(option_extensions.keys()):
         option_extensions[name].prestart(args)
+
+    # If 'launch-prefix' launch file argument is also provided in the user input,
+    # the 'launch-prefix' option is applied since the last duplicate argument is used
+    if args is not None and args.launch_prefix is not None and len(args.launch_prefix) > 0:
+        launch_file_arguments.append(f'launch-prefix:={args.launch_prefix}')
+
     launch_service = launch.LaunchService(
         argv=launch_file_arguments,
         noninteractive=noninteractive,
         debug=debug)
+
     parsed_launch_arguments = parse_launch_arguments(launch_file_arguments)
     # Include the user provided launch file using IncludeLaunchDescription so that the
     # location of the current launch file is set.

--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -25,6 +25,7 @@ from ament_index_python.packages import PackageNotFoundError
 import launch
 from launch.frontend import Parser
 from launch.launch_description_sources import get_launch_description_from_any_launch_file
+from launch.substitutions import TextSubstitution
 
 
 class MultipleLaunchFilesError(Exception):
@@ -153,15 +154,16 @@ def launch_a_launch_file(
     for name in sorted(option_extensions.keys()):
         option_extensions[name].prestart(args)
 
-    # If 'launch-prefix' launch file argument is also provided in the user input,
-    # the 'launch-prefix' option is applied since the last duplicate argument is used
-    if args is not None and args.launch_prefix is not None and len(args.launch_prefix) > 0:
-        launch_file_arguments.append(f'launch-prefix:={args.launch_prefix}')
+    prefix_sub = None
+    if args.launch_prefix is not None:
+        prefix_sub = TextSubstitution(text=args.launch_prefix)
 
     launch_service = launch.LaunchService(
         argv=launch_file_arguments,
         noninteractive=noninteractive,
-        debug=debug)
+        debug=debug,
+        launch_prefix=prefix_sub
+    )
 
     parsed_launch_arguments = parse_launch_arguments(launch_file_arguments)
     # Include the user provided launch file using IncludeLaunchDescription so that the

--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -25,7 +25,6 @@ from ament_index_python.packages import PackageNotFoundError
 import launch
 from launch.frontend import Parser
 from launch.launch_description_sources import get_launch_description_from_any_launch_file
-from launch.substitutions import TextSubstitution
 
 
 class MultipleLaunchFilesError(Exception):
@@ -154,16 +153,15 @@ def launch_a_launch_file(
     for name in sorted(option_extensions.keys()):
         option_extensions[name].prestart(args)
 
-    prefix_sub = None
-    if args.launch_prefix is not None:
-        prefix_sub = TextSubstitution(text=args.launch_prefix)
+    # If 'launch-prefix' launch file argument is also provided in the user input,
+    # the 'launch-prefix' option is applied since the last duplicate argument is used
+    if args is not None and args.launch_prefix is not None and len(args.launch_prefix) > 0:
+        launch_file_arguments.append(f'launch-prefix:={args.launch_prefix}')
 
     launch_service = launch.LaunchService(
         argv=launch_file_arguments,
         noninteractive=noninteractive,
-        debug=debug,
-        launch_prefix=prefix_sub
-    )
+        debug=debug)
 
     parsed_launch_arguments = parse_launch_arguments(launch_file_arguments)
     # Include the user provided launch file using IncludeLaunchDescription so that the

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -92,6 +92,12 @@ class LaunchCommand(CommandExtension):
             help=("Show all launched subprocesses' output by overriding their output"
                   ' configuration using the OVERRIDE_LAUNCH_PROCESS_OUTPUT envvar.')
         )
+        parser.add_argument(
+            '--launch-prefix',
+            help='Prefix command, which should go before all executables. '
+                 'Command must be wrapped in quotes if it contains spaces '
+                 "(e.g. --launch-prefix 'xterm -e gdb -ex run --args')."
+        )
         arg = parser.add_argument(
             'package_name',
             help='Name of the ROS package which contains the launch file')


### PR DESCRIPTION
Resolves: ros2#37

Makes `launch-prefix` more accessible by adding a CLI argument `--launch-prefix 'LAUNCH PREFIX'` where `'LAUNCH PREFIX'` is the desired command prefix (wrapped in quotes if it contains spaces). This achieves the same behavior as setting the launch file argument `'launch-prefix:=LAUNCH PREFIX'` which applies the prefix to all executable Actions. For simplicity, the `--launch-prefix` argument mirrors the `--prefix` argument provided by `ros2 run`.

I did not find documentation for the `ros2 launch` command specifically, but I can submit a documentation update PR to https://navigation.ros.org/tutorials/docs/get_backtrace.html if that is the best location for it.