### PR TITLE
Use frontend group dependency & explicit dependencies in ros2launch

### DIFF
--- a/ros2launch/package.xml
+++ b/ros2launch/package.xml
@@ -21,6 +21,10 @@
   <depend>ros2cli</depend>
   <depend>ros2pkg</depend>
 
+  <!-- explicitly depend on the main launch frontends -->
+  <exec_depend>launch_xml</exec_depend>
+  <exec_depend>launch_yaml</exec_depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/ros2launch/package.xml
+++ b/ros2launch/package.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <?xml-model
-  href="http://download.ros.org/schema/package_format2.xsd"
+  href="http://download.ros.org/schema/package_format3.xsd"
   schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<package format="3">
   <name>ros2launch</name>
   <version>0.15.0</version>
   <description>

--- a/ros2launch/package.xml
+++ b/ros2launch/package.xml
@@ -30,6 +30,8 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
+  <group_depend>launch_frontend_packages</group_depend>
+
   <export>
     <build_type>ament_python</build_type>
   </export>


### PR DESCRIPTION
Closes https://github.com/ros2/launch_ros/issues/255

Requires https://github.com/ros2/launch/pull/520

As suggested/discussed under https://github.com/ros2/launch/pull/516#issuecomment-880342455, this uses a group dependency for the launch frontends and declares explicit dependencies on `launch_xml` and `launch_yaml` for `ros2launch`.

Using both a group dependency and hard/explicit dependencies allows this to work fine with binaries (with bloom) and also allows us to include any future launch frontend (or any user's custom frontend) in source builds. This is similar to how `rcl` depends on both the `rcl_logging_packages` group and the default logging implementation explicitly.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>