### PR TITLE
Add regex filter for selective launch-prefix application

### DIFF
--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -156,7 +156,7 @@ def launch_a_launch_file(
     if args and args.launch_prefix:
         launch_file_arguments.append(f'launch-prefix:={args.launch_prefix}')
 
-    if args.launch_prefix_filter is not None and len(args.launch_prefix_filter):
+    if args and args.launch_prefix_filter:
         launch_file_arguments.append(f'launch-prefix-filter:={args.launch_prefix_filter}')
 
     launch_service = launch.LaunchService(

--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -156,6 +156,15 @@ def launch_a_launch_file(
     if args is not None and args.launch_prefix is not None and len(args.launch_prefix) > 0:
         launch_file_arguments.append(f'launch-prefix:={args.launch_prefix}')
 
+    # Pass launch prefix filter as a forward-slash separated list
+    if args is not None and args.launch_prefix_filter is not None:
+        filter_str = ''
+        for exec_str in args.launch_prefix_filter:
+            filter_str += f'{exec_str}/'
+        filter_str = filter_str.strip('/')
+        if len(filter_str):
+            launch_file_arguments.append(f'launch-prefix-filter:={filter_str}')
+
     launch_service = launch.LaunchService(
         argv=launch_file_arguments,
         noninteractive=noninteractive,

--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -153,7 +153,7 @@ def launch_a_launch_file(
 
     # If 'launch-prefix' launch file argument is also provided in the user input,
     # the 'launch-prefix' option is applied since the last duplicate argument is used
-    if args.launch_prefix is not None and len(args.launch_prefix):
+    if args and args.launch_prefix:
         launch_file_arguments.append(f'launch-prefix:={args.launch_prefix}')
 
     if args.launch_prefix_filter is not None and len(args.launch_prefix_filter):

--- a/ros2launch/ros2launch/api/api.py
+++ b/ros2launch/ros2launch/api/api.py
@@ -153,17 +153,11 @@ def launch_a_launch_file(
 
     # If 'launch-prefix' launch file argument is also provided in the user input,
     # the 'launch-prefix' option is applied since the last duplicate argument is used
-    if args is not None and args.launch_prefix is not None and len(args.launch_prefix) > 0:
+    if args.launch_prefix is not None and len(args.launch_prefix):
         launch_file_arguments.append(f'launch-prefix:={args.launch_prefix}')
 
-    # Pass launch prefix filter as a forward-slash separated list
-    if args is not None and args.launch_prefix_filter is not None:
-        filter_str = ''
-        for exec_str in args.launch_prefix_filter:
-            filter_str += f'{exec_str}/'
-        filter_str = filter_str.strip('/')
-        if len(filter_str):
-            launch_file_arguments.append(f'launch-prefix-filter:={filter_str}')
+    if args.launch_prefix_filter is not None and len(args.launch_prefix_filter):
+        launch_file_arguments.append(f'launch-prefix-filter:={args.launch_prefix_filter}')
 
     launch_service = launch.LaunchService(
         argv=launch_file_arguments,

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -99,7 +99,6 @@ class LaunchCommand(CommandExtension):
         )
         parser.add_argument(
             '--launch-prefix-filter',
-            type=str,
             help=('Regex pattern for filtering which executables the --launch-prefix is applied '
                   'to by matching the executable name.')
         )

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -160,7 +160,7 @@ class LaunchCommand(CommandExtension):
 
         if args.launch_prefix is None and args.launch_prefix_filter is not None:
             raise RuntimeError(
-                "--launch-prefix must be specified if --launch-prefix-filter is provided")
+                '--launch-prefix must be specified if --launch-prefix-filter is provided')
 
         if args.show_all_subprocesses_output:
             os.environ['OVERRIDE_LAUNCH_PROCESS_OUTPUT'] = 'both'

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -97,6 +97,13 @@ class LaunchCommand(CommandExtension):
                  'Command must be wrapped in quotes if it contains spaces '
                  "(e.g. --launch-prefix 'xterm -e gdb -ex run --args')."
         )
+        parser.add_argument(
+            '--launch-prefix-filter',
+            nargs='+',
+            default=[],
+            help=('Filter which executables the --launch-prefix is applied '
+                  'to by their executable name.')
+        )
         arg = parser.add_argument(
             'package_name',
             help='Name of the ROS package which contains the launch file')

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -161,7 +161,7 @@ class LaunchCommand(CommandExtension):
 
         if args.launch_prefix is None and args.launch_prefix_filter is not None:
             raise RuntimeError(
-                "--launch-prefix must specified if --launch-prefix-filter is provided")
+                "--launch-prefix must be specified if --launch-prefix-filter is provided")
 
         if args.show_all_subprocesses_output:
             os.environ['OVERRIDE_LAUNCH_PROCESS_OUTPUT'] = 'both'

--- a/ros2launch/ros2launch/command/launch.py
+++ b/ros2launch/ros2launch/command/launch.py
@@ -99,10 +99,9 @@ class LaunchCommand(CommandExtension):
         )
         parser.add_argument(
             '--launch-prefix-filter',
-            nargs='+',
-            default=[],
-            help=('Filter which executables the --launch-prefix is applied '
-                  'to by their executable name.')
+            type=str,
+            help=('Regex pattern for filtering which executables the --launch-prefix is applied '
+                  'to by matching the executable name.')
         )
         arg = parser.add_argument(
             'package_name',
@@ -159,6 +158,10 @@ class LaunchCommand(CommandExtension):
         else:
             raise RuntimeError('unexpected mode')
         launch_arguments.extend(args.launch_arguments)
+
+        if args.launch_prefix is None and args.launch_prefix_filter is not None:
+            raise RuntimeError(
+                "--launch-prefix must specified if --launch-prefix-filter is provided")
 
         if args.show_all_subprocesses_output:
             os.environ['OVERRIDE_LAUNCH_PROCESS_OUTPUT'] = 'both'


### PR DESCRIPTION
Resolves #257 

This PR shouldn't be merged until #254 and https://github.com/ros2/launch/pull/522 have been accepted and merged.

This PR adds the `--launch-prefix-filter` argument discussed in #257 which allows the user to provide a regex pattern that can be used for selectively applying the command prefix (provided via the `--launch-prefix` argument) to executables which match the pattern. This will allow an easier debugging experience without having to edit the launch file.