### PR TITLE
Handle substitutions in RosTimer

### DIFF
--- a/launch_ros/launch_ros/actions/ros_timer.py
+++ b/launch_ros/launch_ros/actions/ros_timer.py
@@ -75,7 +75,7 @@ class RosTimer(TimerAction):
     async def _wait_to_fire_event(self, context):
         node = get_ros_node(context)
         node.create_timer(
-            self.__period,
+            type_utils.perform_typed_substitution(context, self.__period, float),
             partial(context.asyncio_loop.call_soon_threadsafe, self.__timer_callback),
         )
 

--- a/test_launch_ros/test/test_launch_ros/actions/test_ros_timer.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_ros_timer.py
@@ -20,6 +20,8 @@ import time
 
 from builtin_interfaces.msg import Time
 import launch
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 import launch.event_handlers
 from launch_ros.actions import RosTimer
 from launch_ros.actions import SetUseSimTime
@@ -63,6 +65,21 @@ def test_multiple_launch_with_timers():
     ls = launch.LaunchService()
     ls.include_launch_description(generate_launch_description())
     assert 0 == ls.run()
+
+    ls = launch.LaunchService()
+    ls.include_launch_description(generate_launch_description())
+    assert 0 == ls.run()
+
+
+def test_timer_with_launch_configuration():
+    def generate_launch_description():
+        return launch.LaunchDescription([
+            DeclareLaunchArgument('my_period', default_value='0.1'),
+            RosTimer(
+                period=LaunchConfiguration('my_period'),
+                actions=[]
+            ),
+        ])
 
     ls = launch.LaunchService()
     ls.include_launch_description(generate_launch_description())

--- a/test_launch_ros/test/test_launch_ros/actions/test_ros_timer.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_ros_timer.py
@@ -21,8 +21,8 @@ import time
 from builtin_interfaces.msg import Time
 import launch
 from launch.actions import DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
 import launch.event_handlers
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import RosTimer
 from launch_ros.actions import SetUseSimTime
 import rclpy


### PR DESCRIPTION
Previously, passing a substitution (e.g. LaunchConfiguration) to the RosTimer action would result in a runtime error.