### PR TITLE
[foxy] Fix problems when parsing a Command Substitution as a parameter value (#137)

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -23,6 +23,7 @@ from typing import List
 from typing import Optional
 from typing import Text  # noqa: F401
 from typing import Tuple  # noqa: F401
+from typing import TYPE_CHECKING
 from typing import Union
 
 import warnings
@@ -32,11 +33,12 @@ from launch.actions import ExecuteProcess
 from launch.frontend import Entity
 from launch.frontend import expose_action
 from launch.frontend import Parser
+from launch.frontend.type_utils import get_data_type_from_identifier
+
 from launch.launch_context import LaunchContext
 import launch.logging
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.substitutions import LocalSubstitution
-from launch.substitutions import TextSubstitution
 from launch.utilities import ensure_argument_type
 from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
@@ -56,6 +58,9 @@ from rclpy.validate_namespace import validate_namespace
 from rclpy.validate_node_name import validate_node_name
 
 import yaml
+
+if TYPE_CHECKING:
+    from ..descriptions import Parameter
 
 
 @expose_action('node')
@@ -164,6 +169,7 @@ class Node(ExecuteProcess):
                     "Only use 'executable'"
                 )
             executable = node_executable
+
         if package is not None:
             cmd = [ExecutableInPackage(package=package, executable=executable)]
         else:
@@ -212,7 +218,7 @@ class Node(ExecuteProcess):
 
         self.__expanded_node_name = self.UNSPECIFIED_NODE_NAME
         self.__expanded_node_namespace = self.UNSPECIFIED_NODE_NAMESPACE
-        self.__expanded_parameter_files = None  # type: Optional[List[Text]]
+        self.__expanded_parameter_arguments = None  # type: Optional[List[Tuple[Text, bool]]]
         self.__final_node_name = None  # type: Optional[Text]
         self.__expanded_remappings = None  # type: Optional[List[Tuple[Text, Text]]]
 
@@ -223,27 +229,28 @@ class Node(ExecuteProcess):
     @staticmethod
     def parse_nested_parameters(params, parser):
         """Normalize parameters as expected by Node constructor argument."""
+        from ..descriptions import ParameterValue
+
         def get_nested_dictionary_from_nested_key_value_pairs(params):
             """Convert nested params in a nested dictionary."""
             param_dict = {}
             for param in params:
                 name = tuple(parser.parse_substitution(param.get_attr('name')))
-                value = param.get_attr('value', data_type=None, optional=True)
+                type_identifier = param.get_attr('type', data_type=None, optional=True)
+                data_type = None
+                if type_identifier is not None:
+                    data_type = get_data_type_from_identifier(type_identifier)
+                value = param.get_attr('value', data_type=data_type, optional=True)
                 nested_params = param.get_attr('param', data_type=List[Entity], optional=True)
                 if value is not None and nested_params:
-                    raise RuntimeError('param and value attributes are mutually exclusive')
+                    raise RuntimeError(
+                        'nested parameters and value attributes are mutually exclusive')
+                if data_type is not None and nested_params:
+                    raise RuntimeError(
+                        'nested parameters and type attributes are mutually exclusive')
                 elif value is not None:
-                    def normalize_scalar_value(value):
-                        if isinstance(value, str):
-                            value = parser.parse_substitution(value)
-                            if len(value) == 1 and isinstance(value[0], TextSubstitution):
-                                value = value[0].text  # python `str` are not converted like yaml
-                        return value
-                    if isinstance(value, list):
-                        value = [normalize_scalar_value(x) for x in value]
-                    else:
-                        value = normalize_scalar_value(value)
-                    param_dict[name] = value
+                    some_value = parser.parse_if_substitutions(value)
+                    param_dict[name] = ParameterValue(some_value, value_type=data_type)
                 elif nested_params:
                     param_dict.update({
                         name: get_nested_dictionary_from_nested_key_value_pairs(nested_params)
@@ -330,7 +337,13 @@ class Node(ExecuteProcess):
             yaml.dump(param_dict, h, default_flow_style=False)
             return param_file_path
 
+    def _get_parameter_rule(self, param: 'Parameter', context: LaunchContext):
+        name, value = param.evaluate(context)
+        return f'{name}:={yaml.dump(value)}'
+
     def _perform_substitutions(self, context: LaunchContext) -> None:
+        # Here to avoid cyclic import
+        from ..descriptions import Parameter
         try:
             if self.__substitutions_performed:
                 # This function may have already been called by a subclass' `execute`, for example.
@@ -370,31 +383,36 @@ class Node(ExecuteProcess):
         # so they can be overriden with specific parameters of this Node
         global_params = context.launch_configurations.get('ros_params', None)
         if global_params is not None or self.__parameters is not None:
-            self.__expanded_parameter_files = []
+            self.__expanded_parameter_arguments = []
         if global_params is not None:
             param_file_path = self._create_params_file_from_dict(global_params)
-            self.__expanded_parameter_files.append(param_file_path)
+            self.__expanded_parameter_arguments.append((param_file_path, True))
             cmd_extension = ['--params-file', f'{param_file_path}']
             self.cmd.extend([normalize_to_list_of_substitutions(x) for x in cmd_extension])
             assert os.path.isfile(param_file_path)
         # expand parameters too
         if self.__parameters is not None:
             evaluated_parameters = evaluate_parameters(context, self.__parameters)
-            for i, params in enumerate(evaluated_parameters):
+            for params in evaluated_parameters:
+                is_file = False
                 if isinstance(params, dict):
-                    param_file_path = self._create_params_file_from_dict(params)
-                    assert os.path.isfile(param_file_path)
+                    param_argument = self._create_params_file_from_dict(params)
+                    is_file = True
+                    assert os.path.isfile(param_argument)
                 elif isinstance(params, pathlib.Path):
-                    param_file_path = str(params)
+                    param_argument = str(params)
+                    is_file = True
+                elif isinstance(params, Parameter):
+                    param_argument = self._get_parameter_rule(params, context)
                 else:
                     raise RuntimeError('invalid normalized parameters {}'.format(repr(params)))
-                if not os.path.isfile(param_file_path):
+                if is_file and not os.path.isfile(param_argument):
                     self.__logger.warning(
-                        'Parameter file path is not a file: {}'.format(param_file_path),
+                        'Parameter file path is not a file: {}'.format(param_argument),
                     )
                     continue
-                self.__expanded_parameter_files.append(param_file_path)
-                cmd_extension = ['--params-file', f'{param_file_path}']
+                self.__expanded_parameter_arguments.append((param_argument, is_file))
+                cmd_extension = ['--params-file' if is_file else '-p', f'{param_argument}']
                 self.cmd.extend([normalize_to_list_of_substitutions(x) for x in cmd_extension])
         # expand remappings too
         global_remaps = context.launch_configurations.get('ros_remaps', None)

--- a/launch_ros/launch_ros/descriptions/__init__.py
+++ b/launch_ros/launch_ros/descriptions/__init__.py
@@ -15,7 +15,12 @@
 """descriptions Module."""
 
 from .composable_node import ComposableNode
+from ..parameter_descriptions import Parameter
+from ..parameter_descriptions import ParameterValue
+
 
 __all__ = [
     'ComposableNode',
+    'Parameter',
+    'ParameterValue',
 ]

--- a/launch_ros/launch_ros/parameter_descriptions.py
+++ b/launch_ros/launch_ros/parameter_descriptions.py
@@ -1,0 +1,156 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for a description of a Parameter."""
+
+from typing import List
+from typing import Optional
+from typing import Text
+from typing import Tuple
+from typing import TYPE_CHECKING
+from typing import Union
+
+from launch import LaunchContext
+from launch import SomeSubstitutionsType
+from launch import SomeSubstitutionsType_types_tuple
+from launch.substitution import Substitution
+from launch.utilities import ensure_argument_type
+from launch.utilities import normalize_to_list_of_substitutions
+from launch.utilities import perform_substitutions
+from launch.utilities.type_utils import AllowedTypesType
+from launch.utilities.type_utils import normalize_typed_substitution
+from launch.utilities.type_utils import perform_typed_substitution
+from launch.utilities.type_utils import SomeValueType
+
+if TYPE_CHECKING:
+    from .parameters_type import EvaluatedParameterValue
+
+
+class ParameterValue:
+    """Describes a ROS parameter value."""
+
+    def __init__(
+        self,
+        value: SomeValueType,
+        *,
+        value_type: Optional[AllowedTypesType] = None
+    ) -> None:
+        """
+        Construct a parameter value description.
+
+        :param value: Value or substitution that can be resolved to a value.
+        :param value_type: Used when `value` is a substitution, to coerce the result.
+            Can be one of:
+                - Scalar types: int, bool, float, str
+                - List types: List[int], List[bool], List[float], List[str]
+                - None: will use yaml rules, and check that the result matches one of the above.
+        """
+        self.__value = normalize_typed_substitution(value, value_type)
+        self.__value_type = value_type
+        self.__evaluated_parameter_value: Optional['EvaluatedParameterValue'] = None
+
+    @property
+    def value(self) -> SomeValueType:
+        """Getter for parameter value."""
+        if self.__evaluated_parameter_value is not None:
+            return self.__evaluated_parameter_value
+        return self.__value
+
+    @property
+    def value_type(self) -> AllowedTypesType:
+        """Getter for parameter value type."""
+        return self.__value_type
+
+    def __str__(self) -> Text:
+        return (
+            'launch_ros.description.ParameterValue'
+            f'(value={self.value}, value_type={self.value_type})'
+        )
+
+    def evaluate(self, context: LaunchContext) -> 'EvaluatedParameterValue':
+        """Evaluate and return parameter rule."""
+        self.__evaluated_parameter_value = perform_typed_substitution(
+            context, self.value, self.value_type)
+        return self.__evaluated_parameter_value
+
+
+class Parameter:
+    """Describes a ROS parameter."""
+
+    def __init__(
+        self,
+        name: SomeSubstitutionsType,
+        value: SomeValueType,
+        *,
+        value_type: Optional[AllowedTypesType] = None
+    ) -> None:
+        """
+        Construct a parameter description.
+
+        :param name: Name of the parameter.
+        :param value: Value of the parameter.
+        :param value_type: Used when `value` is a substitution, to coerce the result.
+            Can be one of:
+                - A scalar type: `int`, `str`, `float`, `bool`.
+                  `bool` are written like in `yaml`.
+                  Both `1` and `1.` are valid floats.
+                - An uniform list: `List[int]`, `List[str]`, `List[float]`, `List[bool]`.
+                  Lists are written like in `yaml`.
+                - `None`, which means that yaml rules will be used.
+                  The result of the convertion must be one of the above types,
+                  if not `ValueError` is raised.
+            If value is not a substitution and this parameter is provided,
+            it will be used to check `value` type.
+        """
+        ensure_argument_type(name, SomeSubstitutionsType_types_tuple, 'name')
+
+        self.__name = normalize_to_list_of_substitutions(name)
+        self.__parameter_value = ParameterValue(value, value_type=value_type)
+        self.__evaluated_parameter_name: Optional[Text] = None
+        self.__evaluated_parameter_rule: Optional[Tuple[Text, 'EvaluatedParameterValue']] = None
+
+    @property
+    def name(self) -> Union[List[Substitution], Text]:
+        """Getter for parameter name."""
+        if self.__evaluated_parameter_name is not None:
+            return self.__evaluated_parameter_name
+        return self.__name
+
+    @property
+    def value(self) -> SomeValueType:
+        """Getter for parameter value."""
+        return self.__parameter_value.value
+
+    @property
+    def value_type(self) -> AllowedTypesType:
+        """Getter for parameter value type."""
+        return self.__parameter_value.value_type
+
+    def __str__(self) -> Text:
+        return (
+            'launch_ros.description.Parameter'
+            f'(name={self.name}, value={self.value}, value_type={self.value_type})'
+        )
+
+    def evaluate(self, context: LaunchContext) -> Tuple[Text, 'EvaluatedParameterValue']:
+        """Evaluate and return parameter rule."""
+        if self.__evaluated_parameter_rule is not None:
+            return self.__evaluated_parameter_rule
+
+        name = perform_substitutions(context, self.name)
+        value = self.__parameter_value.evaluate(context)
+
+        self.__evaluated_parameter_name = name
+        self.__evaluated_parameter_rule = (name, value)
+        return (name, value)

--- a/launch_ros/launch_ros/parameters_type.py
+++ b/launch_ros/launch_ros/parameters_type.py
@@ -23,20 +23,33 @@ from typing import Sequence
 from typing import Union
 
 from launch.some_substitutions_type import SomeSubstitutionsType
+from launch.some_substitutions_type import SomeSubstitutionsType_types_tuple
 from launch.substitution import Substitution
+
+from .parameter_descriptions import Parameter as ParameterDescription
+from .parameter_descriptions import ParameterValue as ParameterValueDescription
 
 
 # Parameter value types used below
+_SingleValueType_types_tuple = (str, int, float, bool)
 _SingleValueType = Union[str, int, float, bool]
 _MultiValueType = Union[
     Sequence[str], Sequence[int], Sequence[float], Sequence[bool], bytes]
 
 SomeParameterFile = Union[SomeSubstitutionsType, pathlib.Path]
 SomeParameterName = Sequence[Union[Substitution, str]]
-SomeParameterValue = Union[SomeSubstitutionsType,
-                           Sequence[SomeSubstitutionsType],
-                           _SingleValueType,
-                           _MultiValueType]
+SomeParameterValue = Union[
+    ParameterValueDescription,
+    SomeSubstitutionsType,
+    Sequence[SomeSubstitutionsType],
+    _SingleValueType,
+    _MultiValueType
+]
+SomeParameterValue_types_tuple = (
+    SomeSubstitutionsType_types_tuple +
+    _SingleValueType_types_tuple +
+    (bytes,)
+)
 
 # TODO(sloretz) Recursive type when mypy supports them python/mypy#731
 _SomeParametersDict = Mapping[SomeParameterName, Any]
@@ -44,21 +57,25 @@ SomeParametersDict = Mapping[SomeParameterName, Union[SomeParameterValue, _SomeP
 
 # Paths to yaml files with parameters, or dictionaries of parameters, or pairs of
 # parameter names and values
-SomeParameters = Sequence[Union[SomeParameterFile, Mapping[SomeParameterName, SomeParameterValue]]]
+SomeParameters = Sequence[Union[SomeParameterFile, ParameterDescription, SomeParametersDict]]
 
 ParameterFile = Sequence[Substitution]
 ParameterName = Sequence[Substitution]
-ParameterValue = Union[Sequence[Substitution],
-                       Sequence[Sequence[Substitution]],
-                       _SingleValueType,
-                       _MultiValueType]
+ParameterValue = Union[
+    Sequence[Substitution],
+    Sequence[Sequence[Substitution]],
+    _SingleValueType,
+    _MultiValueType,
+    ParameterValueDescription]
 
 # Normalized (flattened to avoid having a recursive type) parameter dict
 ParametersDict = Dict[ParameterName, ParameterValue]
 
 # Normalized parameters
-Parameters = Sequence[Union[ParameterFile, ParametersDict]]
+Parameters = Sequence[Union[ParameterFile, ParametersDict, ParameterDescription]]
 
 EvaluatedParameterValue = Union[_SingleValueType, _MultiValueType]
 # Evaluated parameters: filenames or dictionary after substitutions have been evaluated
-EvaluatedParameters = Sequence[Union[pathlib.Path, Dict[str, EvaluatedParameterValue]]]
+EvaluatedParameters = Sequence[
+    Union[pathlib.Path, ParameterDescription, Dict[str, EvaluatedParameterValue]]
+]

--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -31,6 +31,8 @@ from launch.utilities import perform_substitutions
 
 import yaml
 
+from ..parameter_descriptions import Parameter as ParameterDescription
+from ..parameter_descriptions import ParameterValue as ParameterValueDescription
 from ..parameters_type import EvaluatedParameters
 from ..parameters_type import EvaluatedParameterValue
 from ..parameters_type import Parameters
@@ -113,6 +115,8 @@ def evaluate_parameter_dict(
                 for i, subvalue in enumerate(value):
                     output_value.append(target_type(subvalue))
                     evaluated_value = tuple(output_value)
+        elif isinstance(value, ParameterValueDescription):
+            evaluated_value = value.evaluate(context)
         else:
             # Value is a singular type, so nothing to evaluate
             ensure_argument_type(value, (float, int, str, bool, bytes), 'value')
@@ -140,6 +144,8 @@ def evaluate_parameters(context: LaunchContext, parameters: Parameters) -> Evalu
         if isinstance(param, tuple) and len(param) and isinstance(param[0], Substitution):
             # Evaluate a list of Substitution to a file path
             output_params.append(pathlib.Path(perform_substitutions(context, list(param))))
+        elif isinstance(param, ParameterDescription):
+            output_params.append(param)
         elif isinstance(param, Mapping):
             # It's a list of name/value pairs
             output_params.append(evaluate_parameter_dict(context, param))

--- a/launch_ros/launch_ros/utilities/normalize_parameters.py
+++ b/launch_ros/launch_ros/utilities/normalize_parameters.py
@@ -33,6 +33,8 @@ from launch.utilities import normalize_to_list_of_substitutions
 
 import yaml
 
+from ..parameter_descriptions import Parameter as ParameterDescription
+from ..parameter_descriptions import ParameterValue as ParameterValueDescription
 from ..parameters_type import ParameterFile  # noqa: F401
 from ..parameters_type import Parameters
 from ..parameters_type import ParametersDict
@@ -145,6 +147,8 @@ def normalize_parameter_dict(
             # Flatten recursive dictionaries
             sub_dict = normalize_parameter_dict(value, _prefix=name)
             normalized.update(sub_dict)
+        elif isinstance(value, ParameterValueDescription):
+            normalized[tuple(name)] = value
         elif isinstance(value, str):
             normalized[tuple(name)] = tuple(normalize_to_list_of_substitutions(yaml.dump(value)))
         elif isinstance(value, Substitution):
@@ -179,6 +183,8 @@ def normalize_parameters(parameters: SomeParameters) -> Parameters:
     for param in parameters:
         if isinstance(param, Mapping):
             normalized_params.append(normalize_parameter_dict(param))
+        elif isinstance(param, ParameterDescription):
+            normalized_params.append(param)
         else:
             # It's a path, normalize to a list of substitutions
             if isinstance(param, pathlib.Path):

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -16,6 +16,7 @@
 
 import os
 import pathlib
+from typing import List
 import unittest
 import warnings
 
@@ -24,7 +25,11 @@ from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import Shutdown
 from launch.substitutions import EnvironmentVariable
+
 import launch_ros.actions.node
+from launch_ros.descriptions import Parameter
+from launch_ros.descriptions import ParameterValue
+
 import pytest
 import yaml
 
@@ -135,15 +140,63 @@ class TestNode(unittest.TestCase):
         self._assert_launch_no_errors([node_action])
 
         # Check the expanded parameters.
-        expanded_parameter_files = node_action._Node__expanded_parameter_files
-        assert len(expanded_parameter_files) == 3
+        expanded_parameter_arguments = node_action._Node__expanded_parameter_arguments
+        assert len(expanded_parameter_arguments) == 3
         for i in range(3):
-            assert expanded_parameter_files[i] == str(parameters_file_path)
+            assert expanded_parameter_arguments[i] == (str(parameters_file_path), True)
+
+    def test_launch_node_with_parameter_descriptions(self):
+        """Test launching a node with parameters specified in a dictionary."""
+        os.environ['PARAM1_VALUE'] = 'param1_value'
+        os.environ['PARAM2'] = 'param2'
+        node_action = self._create_node(
+            parameters=[
+                Parameter(
+                    name='param1',
+                    value=EnvironmentVariable(name='PARAM1_VALUE'),
+                    value_type=str,
+                ),
+                Parameter(
+                    name=EnvironmentVariable(name='PARAM2'),
+                    value=[[EnvironmentVariable(name='PARAM2')], '_value'],
+                    value_type=List[str],
+                ),
+                Parameter(
+                    name='param_group1.list_params',
+                    value=[1.2, 3.4],
+                ),
+                Parameter(
+                    name=['param_group1.param_group2.', EnvironmentVariable('PARAM2'), '_values'],
+                    value=['param2_value'],
+                ),
+                Parameter(
+                    name='param3',
+                    value='',
+                ),
+            ],
+        )
+        self._assert_launch_no_errors([node_action])
+
+        expanded_parameter_arguments = node_action._Node__expanded_parameter_arguments
+        assert len(expanded_parameter_arguments) == 5
+        parameters = []
+        for item, is_file in expanded_parameter_arguments:
+            assert not is_file
+            name, value = item.split(':=')
+            parameters.append((name, yaml.load(value)))
+        assert parameters == [
+            ('param1', 'param1_value'),
+            ('param2', ['param2', '_value']),
+            ('param_group1.list_params', [1.2, 3.4]),
+            ('param_group1.param_group2.param2_values', ['param2_value']),
+            ('param3', ''),
+        ]
 
     def test_launch_node_with_parameter_dict(self):
         """Test launching a node with parameters specified in a dictionary."""
         os.environ['PARAM1_VALUE'] = 'param1_value'
         os.environ['PARAM2'] = 'param2'
+        os.environ['PARAM4_INT'] = '100'
         node_action = self._create_node(
             parameters=[{
                 'param1': EnvironmentVariable(name='PARAM1_VALUE'),
@@ -154,15 +207,18 @@ class TestNode(unittest.TestCase):
                         (EnvironmentVariable('PARAM2'), '_values'): ['param2_value'],
                     }
                 },
-                'param3': ''
+                'param3': '',
+                'param4': ParameterValue(EnvironmentVariable(name='PARAM4_INT'), value_type=int),
             }],
         )
         self._assert_launch_no_errors([node_action])
 
         # Check the expanded parameters (will be written to a file).
-        expanded_parameter_files = node_action._Node__expanded_parameter_files
-        assert len(expanded_parameter_files) == 1
-        with open(expanded_parameter_files[0], 'r') as h:
+        expanded_parameter_arguments = node_action._Node__expanded_parameter_arguments
+        assert len(expanded_parameter_arguments) == 1
+        file_path, is_file = expanded_parameter_arguments[0]
+        assert is_file
+        with open(file_path, 'r') as h:
             expanded_parameters_dict = yaml.load(h, Loader=yaml.FullLoader)
             assert expanded_parameters_dict == {
                 '/my_ns/my_node': {
@@ -170,6 +226,7 @@ class TestNode(unittest.TestCase):
                         'param1': 'param1_value',
                         'param2': 'param2_value',
                         'param3': '',
+                        'param4': 100,
                         'param_group1.list_params': (1.2, 3.4),
                         'param_group1.param_group2.param2_values': ('param2_value',),
                     }

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -183,7 +183,7 @@ class TestNode(unittest.TestCase):
         for item, is_file in expanded_parameter_arguments:
             assert not is_file
             name, value = item.split(':=')
-            parameters.append((name, yaml.load(value)))
+            parameters.append((name, yaml.safe_load(value)))
         assert parameters == [
             ('param1', 'param1_value'),
             ('param2', ['param2', '_value']),

--- a/test_launch_ros/test/test_launch_ros/actions/test_set_parameter.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_set_parameter.py
@@ -106,16 +106,20 @@ def test_set_param_with_node():
     set_param = SetParameter(name='my_param', value='my_value')
     set_param.execute(lc)
     node._perform_substitutions(lc)
-    expanded_parameter_files = node._Node__expanded_parameter_files
-    assert len(expanded_parameter_files) == 2
-    with open(expanded_parameter_files[0], 'r') as h:
+    expanded_parameter_arguments = node._Node__expanded_parameter_arguments
+    assert len(expanded_parameter_arguments) == 2
+    param_file_path, is_file = expanded_parameter_arguments[0]
+    assert is_file
+    with open(param_file_path, 'r') as h:
         expanded_parameters_dict = yaml.load(h, Loader=yaml.FullLoader)
         assert expanded_parameters_dict == {
             '/my_ns/my_node': {
                 'ros__parameters': {'my_param': 'my_value'}
             }
         }
-    with open(expanded_parameter_files[1], 'r') as h:
+    param_file_path, is_file = expanded_parameter_arguments[1]
+    assert is_file
+    with open(param_file_path, 'r') as h:
         expanded_parameters_dict = yaml.load(h, Loader=yaml.FullLoader)
         assert expanded_parameters_dict == {
             '/my_ns/my_node': {

--- a/test_launch_ros/test/test_launch_ros/descriptions/test_parameter.py
+++ b/test_launch_ros/test/test_launch_ros/descriptions/test_parameter.py
@@ -1,0 +1,167 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test type checking/coercion utils."""
+
+from typing import List
+
+from launch import LaunchContext
+from launch.substitutions import TextSubstitution
+
+from launch_ros.descriptions import Parameter
+from launch_ros.descriptions import ParameterValue
+
+import pytest
+
+
+class MockContext:
+
+    def __init__(self):
+        self.launch_configurations = {}
+
+    def perform_substitution(self, sub):
+        return sub.perform(None)
+
+
+def test_parameter_value_description():
+    lc = MockContext()
+
+    param = ParameterValue(value='asd')
+    assert param.value == 'asd'
+    assert param.value_type is None
+    assert param.evaluate(lc) == 'asd'
+    # After the first `evaluate` call, the following `.value` and `.evaluate()`
+    # calls are calculated differently. Test them too.
+    assert param.value == 'asd'
+    assert param.evaluate(lc) == 'asd'
+
+    param = ParameterValue(value='asd', value_type=str)
+    assert param.value == 'asd'
+    assert param.value_type is str
+    assert param.evaluate(lc) == 'asd'
+    assert param.value == 'asd'
+    assert param.evaluate(lc) == 'asd'
+
+    param = ParameterValue(value=TextSubstitution(text='1'))
+    assert isinstance(param.value, list)
+    assert len(param.value) == 1
+    assert isinstance(param.value[0], TextSubstitution)
+    assert param.evaluate(lc) == 1
+    assert param.value == 1
+    assert param.evaluate(lc) == 1
+
+    param = ParameterValue(
+        value=[
+            '[',
+            TextSubstitution(text='1, '),
+            TextSubstitution(text='2, '),
+            TextSubstitution(text='3, '),
+            ']',
+        ],
+        value_type=List[int],
+    )
+    assert isinstance(param.value, list)
+    assert param.evaluate(lc) == [1, 2, 3]
+    assert param.value == [1, 2, 3]
+    assert param.evaluate(lc) == [1, 2, 3]
+
+    param = ParameterValue(
+        value=TextSubstitution(text='[1, 2, 3]'),
+    )
+    assert isinstance(param.value, list)
+    assert len(param.value) == 1
+    assert isinstance(param.value[0], TextSubstitution)
+    assert param.evaluate(lc) == [1, 2, 3]
+    assert param.value == [1, 2, 3]
+    assert param.evaluate(lc) == [1, 2, 3]
+
+    with pytest.raises(TypeError):
+        ParameterValue(value='1', value_type=int)
+
+    param = ParameterValue(
+        value=TextSubstitution(text='[1, asd, 3]')
+    )
+    with pytest.raises(ValueError):
+        param.evaluate(lc)
+
+
+def test_parameter_description():
+    lc = LaunchContext()
+
+    param = Parameter(name='my_param', value='asd')
+    assert isinstance(param.name, list)
+    assert len(param.name) == 1
+    assert isinstance(param.name[0], TextSubstitution)
+    assert param.name[0].text == 'my_param'
+    assert param.value == 'asd'
+    assert param.value_type is None
+    assert param.evaluate(lc) == ('my_param', 'asd')
+    # After the first `evaluate` call, the followings `.name` `.value` and `.evaluate()`
+    # calls are calculated differently. Test them too.
+    assert param.name == 'my_param'
+    assert param.value == 'asd'
+    assert param.evaluate(lc) == ('my_param', 'asd')
+
+    param = Parameter(name='my_param', value='asd', value_type=str)
+    assert isinstance(param.name, list)
+    assert len(param.name) == 1
+    assert isinstance(param.name[0], TextSubstitution)
+    assert param.name[0].text == 'my_param'
+    assert param.value == 'asd'
+    assert param.value_type is str
+    assert param.evaluate(lc) == ('my_param', 'asd')
+    assert param.name == 'my_param'
+    assert param.value == 'asd'
+    assert param.evaluate(lc) == ('my_param', 'asd')
+
+    param = Parameter(name='my_param', value=TextSubstitution(text='1'))
+    assert isinstance(param.value, list)
+    assert len(param.value) == 1
+    assert isinstance(param.value[0], TextSubstitution)
+    assert param.evaluate(lc) == ('my_param', 1)
+    assert (param.name, param.value) == param.evaluate(lc)
+
+    param = Parameter(
+        name='my_param',
+        value=[
+            '[',
+            TextSubstitution(text='1, '),
+            TextSubstitution(text='2, '),
+            TextSubstitution(text='3, '),
+            ']',
+        ],
+        value_type=List[int],
+    )
+    assert isinstance(param.value, list)
+    assert param.evaluate(lc) == ('my_param', [1, 2, 3])
+
+    param = Parameter(
+        name='my_param',
+        value=TextSubstitution(text='[1, 2, 3]'),
+    )
+    assert isinstance(param.value, list)
+    assert len(param.value) == 1
+    assert isinstance(param.value[0], TextSubstitution)
+    assert param.evaluate(lc) == ('my_param', [1, 2, 3])
+    assert (param.name, param.value) == param.evaluate(lc)
+
+    with pytest.raises(TypeError):
+        Parameter(name='my_param', value='1', value_type=int)
+
+    param = Parameter(
+        name='my_param',
+        value=TextSubstitution(text='[1, asd, 3]')
+    )
+    with pytest.raises(ValueError):
+        param.evaluate(lc)

--- a/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
@@ -30,12 +30,13 @@ yaml_params = yaml_params.replace('\\', '\\\\')
 python_executable = sys.executable.replace('\\', '\\\\')
 
 
-def test_launch_remapping_xml():
+def test_launch_frontend_xml():
     xml_file = textwrap.dedent(
         r"""
         <launch>
             <let name="a_string" value="\'[2, 5, 8]\'"/>
             <let name="a_list" value="[2, 5, 8]"/>
+            <let name="my_value" value="100"/>
             <node pkg="demo_nodes_py" exec="talker_qos" output="screen" name="my_talker" namespace="my_ns" exec_name="my_talker_process" args="--number_of_cycles 1">
                 <param name="param1" value="ads"/>
                 <param name="param_group1">
@@ -47,13 +48,14 @@ def test_launch_remapping_xml():
                     <param name="param5" value="$(var a_string)"/>
                     <param name="param6" value="2., 5., 8." value-sep=", "/>
                     <param name="param7" value="'2', '5', '8'" value-sep=", "/>
-                    <!-- TODO(hidmic): revisit after https://github.com/ros2/launch_ros/pull/137 gets merged -->
                     <param name="param8" value="&quot;'2'&quot;, &quot;'5'&quot;, &quot;'8'&quot;" value-sep=", "/>
                     <param name="param9" value="\'2\', \'5\', \'8\'" value-sep=", "/>
-                    <!-- TODO(hidmic): revisit after https://github.com/ros2/launch_ros/pull/137 gets merged -->
                     <param name="param10" value="&quot;'asd'&quot;, &quot;'bsd'&quot;, &quot;'csd'&quot;" value-sep=", "/>
                     <param name="param11" value="'\asd', '\bsd', '\csd'" value-sep=", "/>
-                    <param name="param12" value=""/>
+                    <param name="param12" value="''"/>
+                    <param name="param13" value="$(var my_value)" type="str"/>
+                    <param name="param14" value="'2', '5', '8'" value-sep=", " type="list_of_str"/>
+                    <param name="param15" value="2, 5, 8" value-sep=", " type="list_of_str"/>
                 </param>
                 <param from="{}"/>
                 <env name="var" value="1"/>
@@ -65,10 +67,10 @@ def test_launch_remapping_xml():
         """.format(yaml_params, python_executable))  # noqa: E501
 
     with io.StringIO(xml_file) as f:
-        check_launch_remapping(f)
+        check_launch_node(f)
 
 
-def test_launch_remapping_yaml():
+def test_launch_frontend_yaml():
     yaml_file = textwrap.dedent(
         r"""
         launch:
@@ -78,6 +80,9 @@ def test_launch_remapping_yaml():
             - let:
                 name: 'a_list'
                 value: '[2, 5, 8]'
+            - let:
+                name: 'my_value'
+                value: '100'
             - node:
                 pkg: demo_nodes_py
                 exec: talker_qos
@@ -115,6 +120,15 @@ def test_launch_remapping_yaml():
                             value: ['\asd', '\bsd', '\csd']
                         -   name: param12
                             value: ''
+                        -   name: param13
+                            value: '$(var my_value)'
+                            type: str
+                        -   name: param14
+                            value: ["'2'", "'5'", "'8'"]
+                            type: list_of_str
+                        -   name: param15
+                            value: ['2', '5', '8']
+                            type: list_of_str
                     -   from: {}
                 env:
                     -   name: var
@@ -133,10 +147,10 @@ def test_launch_remapping_yaml():
         """.format(yaml_params, python_executable))  # noqa: E501
 
     with io.StringIO(yaml_file) as f:
-        check_launch_remapping(f)
+        check_launch_node(f)
 
 
-def check_launch_remapping(file):
+def check_launch_node(file):
     root_entity, parser = Parser.load(file)
     ld = parser.parse_description(root_entity)
     ls = LaunchService()
@@ -144,8 +158,9 @@ def check_launch_remapping(file):
     assert(0 == ls.run())
     evaluated_parameters = evaluate_parameters(
         ls.context,
-        ld.describe_sub_entities()[2]._Node__parameters
+        ld.describe_sub_entities()[3]._Node__parameters
     )
+    assert len(evaluated_parameters) == 3
     assert isinstance(evaluated_parameters[0], dict)
     assert isinstance(evaluated_parameters[1], dict)
     assert isinstance(evaluated_parameters[2], pathlib.Path)
@@ -164,24 +179,31 @@ def check_launch_remapping(file):
     assert 'param_group1.param9' in param_dict
     assert 'param_group1.param10' in param_dict
     assert 'param_group1.param11' in param_dict
+    assert 'param_group1.param12' in param_dict
+    assert 'param_group1.param13' in param_dict
+    assert 'param_group1.param14' in param_dict
+    assert 'param_group1.param15' in param_dict
     assert param_dict['param_group1.param_group2.param2'] == 2
-    assert param_dict['param_group1.param3'] == (2, 5, 8)
-    assert param_dict['param_group1.param4'] == (2, 5, 8)
+    assert param_dict['param_group1.param3'] == [2, 5, 8]
+    assert param_dict['param_group1.param4'] == [2, 5, 8]
     assert param_dict['param_group1.param5'] == '[2, 5, 8]'
-    assert param_dict['param_group1.param6'] == (2., 5., 8.)
-    assert param_dict['param_group1.param7'] == ('2', '5', '8')
-    assert param_dict['param_group1.param8'] == ("'2'", "'5'", "'8'")
-    assert param_dict['param_group1.param9'] == ("'2'", "'5'", "'8'")
-    assert param_dict['param_group1.param10'] == ("'asd'", "'bsd'", "'csd'")
-    assert param_dict['param_group1.param11'] == ('asd', 'bsd', 'csd')
+    assert param_dict['param_group1.param6'] == [2., 5., 8.]
+    assert param_dict['param_group1.param7'] == ['2', '5', '8']
+    assert param_dict['param_group1.param8'] == ["'2'", "'5'", "'8'"]
+    assert param_dict['param_group1.param9'] == ["'2'", "'5'", "'8'"]
+    assert param_dict['param_group1.param10'] == ["'asd'", "'bsd'", "'csd'"]
+    assert param_dict['param_group1.param11'] == ['asd', 'bsd', 'csd']
     assert param_dict['param_group1.param12'] == ''
+    assert param_dict['param_group1.param13'] == '100'
+    assert param_dict['param_group1.param14'] == ["'2'", "'5'", "'8'"]
+    assert param_dict['param_group1.param15'] == ['2', '5', '8']
 
     # Check remappings exist
-    remappings = ld.describe_sub_entities()[2]._Node__remappings
+    remappings = ld.describe_sub_entities()[3]._Node__remappings
     assert remappings is not None
     assert len(remappings) == 2
 
-    listener_node_action = ld.describe_sub_entities()[3]
+    listener_node_action = ld.describe_sub_entities()[4]
     listener_node_cmd = listener_node_action.process_details['cmd']
     assert [
         sys.executable, '-c', 'import sys; print(sys.argv[1:])'

--- a/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2020 Open Avatar Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Example of how to parse an xml."""
-
 import io
 import pathlib
 import sys
@@ -24,114 +23,119 @@ from launch.frontend import Parser
 
 from launch_ros.utilities import evaluate_parameters
 
-import pytest
-
 yaml_params = str(pathlib.Path(__file__).parent / 'params.yaml')
 
 # Escape backslashes if any to keep them after parsing takes place
 yaml_params = yaml_params.replace('\\', '\\\\')
 python_executable = sys.executable.replace('\\', '\\\\')
 
-xml_file = \
-    r"""
-    <launch>
-        <let name="a_string" value="\'[2, 5, 8]\'"/>
-        <let name="a_list" value="[2, 5, 8]"/>
-        <node pkg="demo_nodes_py" exec="talker_qos" output="screen" name="my_talker" namespace="my_ns" exec_name="my_talker_process" args="--number_of_cycles 1">
-            <param name="param1" value="ads"/>
-            <param name="param_group1">
-                <param name="param_group2">
-                    <param name="param2" value="2"/>
+
+def test_launch_remapping_xml():
+    xml_file = textwrap.dedent(
+        r"""
+        <launch>
+            <let name="a_string" value="\'[2, 5, 8]\'"/>
+            <let name="a_list" value="[2, 5, 8]"/>
+            <node pkg="demo_nodes_py" exec="talker_qos" output="screen" name="my_talker" namespace="my_ns" exec_name="my_talker_process" args="--number_of_cycles 1">
+                <param name="param1" value="ads"/>
+                <param name="param_group1">
+                    <param name="param_group2">
+                        <param name="param2" value="2"/>
+                    </param>
+                    <param name="param3" value="2, 5, 8" value-sep=", "/>
+                    <param name="param4" value="$(var a_list)"/>
+                    <param name="param5" value="$(var a_string)"/>
+                    <param name="param6" value="2., 5., 8." value-sep=", "/>
+                    <param name="param7" value="'2', '5', '8'" value-sep=", "/>
+                    <param name="param8" value="''2'', ''5'', ''8''" value-sep=", "/>
+                    <param name="param9" value="\'2\', \'5\', \'8\'" value-sep=", "/>
+                    <param name="param10" value="''asd'', ''bsd'', ''csd''" value-sep=", "/>
+                    <param name="param11" value="'\asd', '\bsd', '\csd'" value-sep=", "/>
+                    <param name="param12" value=""/>
                 </param>
-                <param name="param3" value="2, 5, 8" value-sep=", "/>
-                <param name="param4" value="$(var a_list)"/>
-                <param name="param5" value="$(var a_string)"/>
-                <param name="param6" value="2., 5., 8." value-sep=", "/>
-                <param name="param7" value="'2', '5', '8'" value-sep=", "/>
-                <param name="param8" value="''2'', ''5'', ''8''" value-sep=", "/>
-                <param name="param9" value="\'2\', \'5\', \'8\'" value-sep=", "/>
-                <param name="param10" value="''asd'', ''bsd'', ''csd''" value-sep=", "/>
-                <param name="param11" value="'\asd', '\bsd', '\csd'" value-sep=", "/>
-                <param name="param12" value=""/>
-            </param>
-            <param from="{}"/>
-            <env name="var" value="1"/>
-            <remap from="foo" to="bar"/>
-            <remap from="baz" to="foobar"/>
-        </node>
-        <node exec="{}" args="-c 'import sys; print(sys.argv[1:])'" name="my_listener" namespace="my_ns" output="screen"/>
-    </launch>
-    """.format(yaml_params, python_executable)  # noqa: E501
-xml_file = textwrap.dedent(xml_file)
-yaml_file = \
-    r"""
-    launch:
-        - let:
-            name: 'a_string'
-            value: "'[2, 5, 8]'"
-        - let:
-            name: 'a_list'
-            value: '[2, 5, 8]'
-        - node:
-            pkg: demo_nodes_py
-            exec: talker_qos
-            output: screen
-            name: my_talker
-            namespace: my_ns
-            exec_name: my_talker_process
-            args: '--number_of_cycles 1'
-            param:
-                -   name: param1
-                    value: ads
-                -   name: param_group1
-                    param:
-                    -   name: param_group2
+                <param from="{}"/>
+                <env name="var" value="1"/>
+                <remap from="foo" to="bar"/>
+                <remap from="baz" to="foobar"/>
+            </node>
+            <node exec="{}" args="-c 'import sys; print(sys.argv[1:])'" name="my_listener" namespace="my_ns" output="screen"/>
+        </launch>
+        """.format(yaml_params, python_executable))  # noqa: E501
+
+    with io.StringIO(xml_file) as f:
+        check_launch_remapping(f)
+
+
+def test_launch_remapping_yaml():
+    yaml_file = textwrap.dedent(
+        r"""
+        launch:
+            - let:
+                name: 'a_string'
+                value: "'[2, 5, 8]'"
+            - let:
+                name: 'a_list'
+                value: '[2, 5, 8]'
+            - node:
+                pkg: demo_nodes_py
+                exec: talker_qos
+                output: screen
+                name: my_talker
+                namespace: my_ns
+                exec_name: my_talker_process
+                args: '--number_of_cycles 1'
+                param:
+                    -   name: param1
+                        value: ads
+                    -   name: param_group1
                         param:
-                        -   name: param2
-                            value: 2
-                    -   name: param3
-                        value: [2, 5, 8]
-                    -   name: param4
-                        value: $(var a_list)
-                    -   name: param5
-                        value: $(var a_string)
-                    -   name: param6
-                        value: [2., 5., 8.]
-                    -   name: param7
-                        value: ['2', '5', '8']
-                    -   name: param8
-                        value: ["'2'", "'5'", "'8'"]
-                    -   name: param9
-                        value: ["\\'2\\'", "\\'5\\'", "\\'8\\'"]
-                    -   name: param10
-                        value: ["'asd'", "'bsd'", "'csd'"]
-                    -   name: param11
-                        value: ['\asd', '\bsd', '\csd']
-                    -   name: param12
-                        value: ''
-                -   from: {}
-            env:
-                -   name: var
-                    value: '1'
-            remap:
-                -   from: "foo"
-                    to: "bar"
-                -   from: "baz"
-                    to: "foobar"
-        - node:
-            exec: {}
-            output: screen
-            namespace: my_ns
-            name: my_listener
-            args: -c 'import sys; print(sys.argv[1:])'
-    """.format(yaml_params, python_executable)  # noqa: E501
-yaml_file = textwrap.dedent(yaml_file)
+                        -   name: param_group2
+                            param:
+                            -   name: param2
+                                value: 2
+                        -   name: param3
+                            value: [2, 5, 8]
+                        -   name: param4
+                            value: $(var a_list)
+                        -   name: param5
+                            value: $(var a_string)
+                        -   name: param6
+                            value: [2., 5., 8.]
+                        -   name: param7
+                            value: ['2', '5', '8']
+                        -   name: param8
+                            value: ["'2'", "'5'", "'8'"]
+                        -   name: param9
+                            value: ["\\'2\\'", "\\'5\\'", "\\'8\\'"]
+                        -   name: param10
+                            value: ["'asd'", "'bsd'", "'csd'"]
+                        -   name: param11
+                            value: ['\asd', '\bsd', '\csd']
+                        -   name: param12
+                            value: ''
+                    -   from: {}
+                env:
+                    -   name: var
+                        value: '1'
+                remap:
+                    -   from: "foo"
+                        to: "bar"
+                    -   from: "baz"
+                        to: "foobar"
+            - node:
+                exec: {}
+                output: screen
+                namespace: my_ns
+                name: my_listener
+                args: -c 'import sys; print(sys.argv[1:])'
+        """.format(yaml_params, python_executable))  # noqa: E501
+
+    with io.StringIO(yaml_file) as f:
+        check_launch_remapping(f)
 
 
-@pytest.mark.parametrize('file', (xml_file, yaml_file))
-def test_node_frontend(file):
-    """Parse node xml example."""
-    root_entity, parser = Parser.load(io.StringIO(file))
+def check_launch_remapping(file):
+    root_entity, parser = Parser.load(file)
     ld = parser.parse_description(root_entity)
     ls = LaunchService()
     ls.include_launch_description(ld)

--- a/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
@@ -47,9 +47,11 @@ def test_launch_remapping_xml():
                     <param name="param5" value="$(var a_string)"/>
                     <param name="param6" value="2., 5., 8." value-sep=", "/>
                     <param name="param7" value="'2', '5', '8'" value-sep=", "/>
-                    <param name="param8" value="''2'', ''5'', ''8''" value-sep=", "/>
+                    <!-- TODO(hidmic): revisit after https://github.com/ros2/launch_ros/pull/137 gets merged -->
+                    <param name="param8" value="&quot;'2'&quot;, &quot;'5'&quot;, &quot;'8'&quot;" value-sep=", "/>
                     <param name="param9" value="\'2\', \'5\', \'8\'" value-sep=", "/>
-                    <param name="param10" value="''asd'', ''bsd'', ''csd''" value-sep=", "/>
+                    <!-- TODO(hidmic): revisit after https://github.com/ros2/launch_ros/pull/137 gets merged -->
+                    <param name="param10" value="&quot;'asd'&quot;, &quot;'bsd'&quot;, &quot;'csd'&quot;" value-sep=", "/>
                     <param name="param11" value="'\asd', '\bsd', '\csd'" value-sep=", "/>
                     <param name="param12" value=""/>
                 </param>

--- a/test_launch_ros/test/test_launch_ros/frontend/test_push_ros_namespace_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_push_ros_namespace_frontend.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Open Source Robotics Foundation, Inc.
+# Copyright 2020 Open Avatar Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,36 +13,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Example of how to parse an xml."""
-
 import io
 import textwrap
 
 from launch import LaunchService
 from launch.frontend import Parser
 
-import pytest
 
-xml_file = \
-    r"""
-    <launch>
-        <push-ros-namespace namespace="asd"/>
-    </launch>
-    """
-xml_file = textwrap.dedent(xml_file)
-yaml_file = \
-    r"""
-    launch:
-        - push-ros-namespace:
-            namespace: 'asd'
-    """
-yaml_file = textwrap.dedent(yaml_file)
+def test_launch_namespace_yaml():
+    yaml_file = textwrap.dedent(
+        r"""
+        launch:
+           - push-ros-namespace:
+               namespace: 'asd'
+        """
+    )
+    with io.StringIO(yaml_file) as f:
+        check_launch_namespace(f)
 
 
-@pytest.mark.parametrize('file', (xml_file, yaml_file))
-def test_node_frontend(file):
-    """Parse node xml example."""
-    root_entity, parser = Parser.load(io.StringIO(file))
+def test_launch_namespace_xml():
+    xml_file = textwrap.dedent(
+        r"""
+        <launch>
+            <push-ros-namespace namespace="asd"/>
+        </launch>
+        """
+    )
+    with io.StringIO(xml_file) as f:
+        check_launch_namespace(f)
+
+
+def check_launch_namespace(file):
+    root_entity, parser = Parser.load(file)
     ld = parser.parse_description(root_entity)
     ls = LaunchService()
     ls.include_launch_description(ld)


### PR DESCRIPTION
Backport #146, #164, and #137 to Foxy. The first two commits are prerequisites for #137.

Backport https://github.com/ros2/launch_ros/pull/175 to fix CI.

Fixes https://github.com/ros2/launch_ros/issues/214
Depends on https://github.com/ros2/launch/pull/530