### PR TITLE
Remove unused code, Future.result() already raises

### DIFF
--- a/launch_testing_ros/test/examples/set_param_launch_test.py
+++ b/launch_testing_ros/test/examples/set_param_launch_test.py
@@ -72,8 +72,4 @@ class MakeTestNode(Node):
         rclpy.spin_until_future_complete(self, future)
 
         response = future.result()
-        if response is None:
-            e = future.exception()
-            raise RuntimeError(
-                f"Exception while calling service of node 'demo_node_1': {e}")
         return response.results[0]


### PR DESCRIPTION
This removes some unused code. `rclpy.task.Future.result()` already raises if there's an exception.

https://github.com/ros2/rclpy/blob/691e4fbfcb4bd4cc2a01182a7dced3105a78200b/rclpy/rclpy/task.py#L93-L94