### PR TITLE
Check that future is done, and always call rclpy.shutdown

### DIFF
--- a/launch_testing_ros/test/examples/check_msgs_launch_test.py
+++ b/launch_testing_ros/test/examples/check_msgs_launch_test.py
@@ -51,11 +51,13 @@ class TestFixture(unittest.TestCase):
 
     def test_check_if_msgs_published(self, proc_output):
         rclpy.init()
-        node = MakeTestNode('test_node')
-        node.start_subscriber()
-        msgs_received_flag = node.msg_event_object.wait(timeout=5.0)
-        assert msgs_received_flag, 'Did not receive msgs !'
-        rclpy.shutdown()
+        try:
+            node = MakeTestNode('test_node')
+            node.start_subscriber()
+            msgs_received_flag = node.msg_event_object.wait(timeout=5.0)
+            assert msgs_received_flag, 'Did not receive msgs !'
+        finally:
+            rclpy.shutdown()
 
 
 class MakeTestNode(Node):

--- a/launch_testing_ros/test/examples/check_node_launch_test.py
+++ b/launch_testing_ros/test/examples/check_node_launch_test.py
@@ -51,9 +51,11 @@ class TestFixture(unittest.TestCase):
 
     def test_node_start(self, proc_output):
         rclpy.init()
-        node = MakeTestNode('test_node')
-        assert node.wait_for_node('demo_node_1', 8.0), 'Node not found !'
-        rclpy.shutdown()
+        try:
+            node = MakeTestNode('test_node')
+            assert node.wait_for_node('demo_node_1', 8.0), 'Node not found !'
+        finally:
+            rclpy.shutdown()
 
 
 class MakeTestNode(Node):

--- a/launch_testing_ros/test/examples/set_param_launch_test.py
+++ b/launch_testing_ros/test/examples/set_param_launch_test.py
@@ -47,10 +47,12 @@ class TestFixture(unittest.TestCase):
 
     def test_set_parameter(self, proc_output):
         rclpy.init()
-        node = MakeTestNode('test_node')
-        response = node.set_parameter(state=True)
-        assert response.successful, 'Could not set parameter!'
-        rclpy.shutdown()
+        try:
+            node = MakeTestNode('test_node')
+            response = node.set_parameter(state=True)
+            assert response.successful, 'Could not set parameter!'
+        finally:
+            rclpy.shutdown()
 
 
 class MakeTestNode(Node):

--- a/launch_testing_ros/test/examples/set_param_launch_test.py
+++ b/launch_testing_ros/test/examples/set_param_launch_test.py
@@ -71,5 +71,7 @@ class MakeTestNode(Node):
         future = client.call_async(request)
         rclpy.spin_until_future_complete(self, future, timeout_sec=timeout)
 
+        assert future.done(), 'Client request timed out'
+
         response = future.result()
         return response.results[0]


### PR DESCRIPTION
This partially undoes #270 - I didn't realize `spin_until_future_complete()` does nothing on timeout, so the future's result could be None. This assert's the future is done before using the result.

The second commit Makes sure `rclpy.shutdown()` is always called. It looks like all the tests are run in the same Python instance, so the tests need to be extra careful when initializing rclpy globally. Using a `try/finally` construct makes sure rclpy will be shutdown for the next test. Otherwise, errors like this one can happen: https://ci.ros2.org/job/ci_windows/15536/consoleText


```
===============================================================================================================================
FAIL: set_param_launch_test.TestFixture.test_set_parameter
-------------------------------------------------------------------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\ci\ws\src\ros2\launch_ros\launch_testing_ros\test\examples\set_param_launch_test.py", line 49, in test_set_parameter
    rclpy.init()
  File "C:\ci\ws\install\Lib\site-packages\rclpy\__init__.py", line 76, in init
    return context.init(args, domain_id=domain_id)
  File "C:\ci\ws\install\Lib\site-packages\rclpy\context.py", line 70, in init
    raise RuntimeError('Context.init() must only be called once')
RuntimeError: Context.init() must only be called once
---------------------------- Captured stdout call -----------------------------
[INFO] [launch]: All log files can be found below C:\Users\ContainerAdministrator\.ros\log\2021-09-30-19-48-41-770984-0cec77497c5b-3144
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [python.exe-3]: process started with pid [872]
[WARNING] [python.exe-3]: 'SIGINT' sent to process[python.exe-3] not supported on Windows, escalating to 'SIGTERM'
[INFO] [python.exe-3]: sending signal 'SIGTERM' to process[python.exe-3]
[ERROR] [python.exe-3]: process has died [pid 872, exit code 1, cmd 'C:\Python38\python.exe C:\ci\ws\src\ros2\launch_ros\launch_testing_ros\test\examples\parameter_blackboard.py --ros-args -r __node:=demo_node_1'].
---------------------------- Captured stderr call -----------------------------
test_set_parameter (set_param_launch_test.TestFixture) ... ERROR

======================================================================
ERROR: test_set_parameter (set_param_launch_test.TestFixture)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\ci\ws\src\ros2\launch_ros\launch_testing_ros\test\examples\set_param_launch_test.py", line 51, in test_set_parameter
    response = node.set_parameter(state=True)
  File "C:\ci\ws\src\ros2\launch_ros\launch_testing_ros\test\examples\set_param_launch_test.py", line 75, in set_parameter
    return response.results[0]
AttributeError: 'NoneType' object has no attribute 'results'
```