### PR TITLE
launch testing : Wait for topics to publish

### DIFF
--- a/launch_testing_ros/launch_testing_ros/__init__.py
+++ b/launch_testing_ros/launch_testing_ros/__init__.py
@@ -17,10 +17,12 @@ from . import tools
 from .data_republisher import DataRepublisher
 from .message_pump import MessagePump
 from .test_runner import LaunchTestRunner
+from . wait_for_topics import WaitForTopics
 
 __all__ = [
     'DataRepublisher',
     'LaunchTestRunner',
     'MessagePump',
     'tools',
+    'WaitForTopics',
 ]

--- a/launch_testing_ros/launch_testing_ros/wait_for_topics.py
+++ b/launch_testing_ros/launch_testing_ros/wait_for_topics.py
@@ -104,7 +104,7 @@ class WaitForTopics:
 
 
 class _WaitForTopicsNode(Node):
-    """Internal dummy node to be used for listening on topics."""
+    """Internal node used for subscribing to a set of topics."""
 
     def __init__(self, name='test_node', node_context=None):
         super().__init__(node_name=name, context=node_context)

--- a/launch_testing_ros/launch_testing_ros/wait_for_topics.py
+++ b/launch_testing_ros/launch_testing_ros/wait_for_topics.py
@@ -1,16 +1,32 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from threading import Event
+from threading import Lock
 from threading import Thread
 
 import rclpy
 from rclpy.node import Node
 
+
 class WaitForTopics:
-    def __init__(self, topic_name, topic_type):
+    """Wait to receive messages on supplied nodes."""
+
+    def __init__(self, topic_tuples):
         self.__ros_context = None
         self.__ros_node = None
-        self.topic_name = topic_name
-        self.topic_type = topic_type
-
+        self.topic_tuples = topic_tuples
         self.start()
 
     def start(self):
@@ -19,7 +35,7 @@ class WaitForTopics:
         self.__ros_node = MakeTestNode(name='test_node')
 
     def wait(self, timeout=5.0):
-        self.__ros_node.start_subscriber(self.topic_name, self.topic_type)
+        self.__ros_node.start_subscribers(self.topic_tuples)
         return self.__ros_node.msg_event_object.wait(timeout)
 
     def shutdown(self):
@@ -27,22 +43,46 @@ class WaitForTopics:
 
 
 class MakeTestNode(Node):
+    """Mock node to be used for listening on topics."""
+
     def __init__(self, name='test_node'):
         super().__init__(node_name=name)
         self.msg_event_object = Event()
+        self.logger = rclpy.logging.get_logger('wait_for_topics')
 
-    def start_subscriber(self, topic_name, topic_type):
-        # Create a subscriber
-        self.subscription = self.create_subscription(
-            topic_type,
-            topic_name,
-            self.subscriber_callback,
-            10
-        )
+    def start_subscribers(self, topic_tuples):
+        self.subscriber_list = []
+        self.expected_topics = [name for name, _ in topic_tuples]
+        self.expected_topics.sort()
+        self.received_topics = []
+        self.topic_mutex = Lock()
+
+        for topic_name, topic_type in topic_tuples:
+            # Create a subscriber
+            self.subscriber_list.append(
+                self.create_subscription(
+                    topic_type,
+                    topic_name,
+                    self.callback_template(topic_name),
+                    10
+                )
+            )
 
         # Add a spin thread
         self.ros_spin_thread = Thread(target=lambda node: rclpy.spin(node), args=(self,))
         self.ros_spin_thread.start()
 
-    def subscriber_callback(self, data):
-        self.msg_event_object.set()
+    def callback_template(self, topic_name):
+
+        def topic_callback(data):
+            self.topic_mutex.acquire()
+            if topic_name not in self.received_topics:
+                self.logger.info('Message received for ' + topic_name)
+                self.received_topics.append(topic_name)
+                self.received_topics.sort()
+            if self.received_topics == self.expected_topics:
+                self.msg_event_object.set()
+
+            self.topic_mutex.release()
+
+        return topic_callback

--- a/launch_testing_ros/launch_testing_ros/wait_for_topics.py
+++ b/launch_testing_ros/launch_testing_ros/wait_for_topics.py
@@ -15,7 +15,6 @@
 import random
 import string
 from threading import Event
-from threading import Lock
 from threading import Thread
 
 import rclpy
@@ -99,7 +98,6 @@ class _WaitForTopicsNode(Node):
         self.subscriber_list = []
         self.expected_topics = {name for name, _ in topic_tuples}
         self.received_topics = set()
-        self.topic_mutex = Lock()
 
         for topic_name, topic_type in topic_tuples:
             # Create a subscriber
@@ -115,13 +113,10 @@ class _WaitForTopicsNode(Node):
     def callback_template(self, topic_name):
 
         def topic_callback(data):
-            self.topic_mutex.acquire()
             if topic_name not in self.received_topics:
                 self.get_logger().debug('Message received for ' + topic_name)
                 self.received_topics.add(topic_name)
             if self.received_topics == self.expected_topics:
                 self.msg_event_object.set()
-
-            self.topic_mutex.release()
 
         return topic_callback

--- a/launch_testing_ros/launch_testing_ros/wait_for_topics.py
+++ b/launch_testing_ros/launch_testing_ros/wait_for_topics.py
@@ -1,0 +1,48 @@
+from threading import Event
+from threading import Thread
+
+import rclpy
+from rclpy.node import Node
+
+class WaitForTopics:
+    def __init__(self, topic_name, topic_type):
+        self.__ros_context = None
+        self.__ros_node = None
+        self.topic_name = topic_name
+        self.topic_type = topic_type
+
+        self.start()
+
+    def start(self):
+        self.__ros_context = rclpy.Context()
+        rclpy.init()
+        self.__ros_node = MakeTestNode(name='test_node')
+
+    def wait(self, timeout=5.0):
+        self.__ros_node.start_subscriber(self.topic_name, self.topic_type)
+        return self.__ros_node.msg_event_object.wait(timeout)
+
+    def shutdown(self):
+        rclpy.shutdown()
+
+
+class MakeTestNode(Node):
+    def __init__(self, name='test_node'):
+        super().__init__(node_name=name)
+        self.msg_event_object = Event()
+
+    def start_subscriber(self, topic_name, topic_type):
+        # Create a subscriber
+        self.subscription = self.create_subscription(
+            topic_type,
+            topic_name,
+            self.subscriber_callback,
+            10
+        )
+
+        # Add a spin thread
+        self.ros_spin_thread = Thread(target=lambda node: rclpy.spin(node), args=(self,))
+        self.ros_spin_thread.start()
+
+    def subscriber_callback(self, data):
+        self.msg_event_object.set()

--- a/launch_testing_ros/launch_testing_ros/wait_for_topics.py
+++ b/launch_testing_ros/launch_testing_ros/wait_for_topics.py
@@ -45,6 +45,7 @@ class WaitForTopics:
         assert wait_for_topics.wait()
         print('Given topics are receiving messages !')
         print(wait_for_topics.topics_not_received()) # Should be an empty set
+        print(wait_for_topics.topics_received()) # Should be {'topic_1', 'topic_2'}
         wait_for_topics.shutdown()
     """
 

--- a/launch_testing_ros/test/examples/wait_for_topic_launch_test.py
+++ b/launch_testing_ros/test/examples/wait_for_topic_launch_test.py
@@ -1,0 +1,91 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+
+import launch
+import launch.actions
+import launch_ros.actions
+import launch_testing.actions
+import launch_testing.markers
+from launch_testing_ros import WaitForTopics
+import pytest
+from std_msgs.msg import String
+
+
+def generate_node(i):
+    """Return node and remap the topic based on the index provided."""
+    path_to_test = os.path.dirname(__file__)
+    return launch_ros.actions.Node(
+        executable=sys.executable,
+        arguments=[os.path.join(path_to_test, 'talker.py')],
+        name='demo_node_' + str(i),
+        additional_env={'PYTHONUNBUFFERED': '1'},
+        remappings=[('chatter', 'chatter_' + str(i))]
+    )
+
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    # 'n' changes the number of nodes and topics generated for this test
+    n = 5
+    description = [generate_node(i) for i in range(n)] + [launch_testing.actions.ReadyToTest()]
+    return launch.LaunchDescription(description), {'count': n}
+
+
+class TestFixture(unittest.TestCase):
+
+    def test_topics_successful(self, count):
+        """All the supplied topics should be read successfully."""
+        topic_list = [('chatter_' + str(i), String) for i in range(count)]
+        expected_topics = {'chatter_' + str(i) for i in range(count)}
+
+        # Method 1 : Using the magic methods and 'with' keyword
+        wait_for_node_object_1 = WaitForTopics(topic_list, timeout=2.0)
+        with wait_for_node_object_1:
+            assert wait_for_node_object_1.topics_received() == expected_topics
+            assert wait_for_node_object_1.topics_not_received() == set()
+
+        # Multiple instances of WaitForNode() can be created safely as
+        # their internal nodes spin in separate contexts
+        # Method 2 : Manually calling wait() and shutdown()
+        wait_for_node_object_2 = WaitForTopics(topic_list, timeout=2.0)
+        assert wait_for_node_object_2.wait()
+        assert wait_for_node_object_2.topics_received() == expected_topics
+        assert wait_for_node_object_2.topics_not_received() == set()
+        wait_for_node_object_2.shutdown()
+
+    def test_topics_unsuccessful(self, count):
+        """All topics should be read except for the 'invalid_topic'."""
+        topic_list = [('chatter_' + str(i), String) for i in range(count)]
+        # Add a topic that will never have anything published on it
+        topic_list.append(('invalid_topic', String))
+        expected_topics = {'chatter_' + str(i) for i in range(count)}
+
+        # Method 1
+        wait_for_node_object_1 = WaitForTopics(topic_list, timeout=2.0)
+        with pytest.raises(RuntimeError):
+            with wait_for_node_object_1:
+                assert wait_for_node_object_1.topics_received() == expected_topics
+                assert wait_for_node_object_1.topics_not_received() == {'invalid_topic'}
+
+        # Method 2
+        wait_for_node_object_2 = WaitForTopics(topic_list, timeout=2.0)
+        assert not wait_for_node_object_2.wait()
+        assert wait_for_node_object_2.topics_received() == expected_topics
+        assert wait_for_node_object_2.topics_not_received() == {'invalid_topic'}
+        wait_for_node_object_2.shutdown()

--- a/launch_testing_ros/test/examples/wait_for_topic_launch_test.py
+++ b/launch_testing_ros/test/examples/wait_for_topic_launch_test.py
@@ -55,8 +55,7 @@ class TestFixture(unittest.TestCase):
         expected_topics = {'chatter_' + str(i) for i in range(count)}
 
         # Method 1 : Using the magic methods and 'with' keyword
-        wait_for_node_object_1 = WaitForTopics(topic_list, timeout=2.0)
-        with wait_for_node_object_1:
+        with WaitForTopics(topic_list, timeout=2.0) as wait_for_node_object_1:
             assert wait_for_node_object_1.topics_received() == expected_topics
             assert wait_for_node_object_1.topics_not_received() == set()
 
@@ -77,15 +76,13 @@ class TestFixture(unittest.TestCase):
         expected_topics = {'chatter_' + str(i) for i in range(count)}
 
         # Method 1
-        wait_for_node_object_1 = WaitForTopics(topic_list, timeout=2.0)
         with pytest.raises(RuntimeError):
-            with wait_for_node_object_1:
-                assert wait_for_node_object_1.topics_received() == expected_topics
-                assert wait_for_node_object_1.topics_not_received() == {'invalid_topic'}
+            with WaitForTopics(topic_list, timeout=2.0):
+                pass
 
         # Method 2
-        wait_for_node_object_2 = WaitForTopics(topic_list, timeout=2.0)
-        assert not wait_for_node_object_2.wait()
-        assert wait_for_node_object_2.topics_received() == expected_topics
-        assert wait_for_node_object_2.topics_not_received() == {'invalid_topic'}
-        wait_for_node_object_2.shutdown()
+        wait_for_node_object = WaitForTopics(topic_list, timeout=2.0)
+        assert not wait_for_node_object.wait()
+        assert wait_for_node_object.topics_received() == expected_topics
+        assert wait_for_node_object.topics_not_received() == {'invalid_topic'}
+        wait_for_node_object.shutdown()


### PR DESCRIPTION
This aims to close https://github.com/ros2/launch_ros/issues/272. It aims to provide an API in to be used with ``launch_testing`` where we provide a set of topics and we wait for at least a single message to appear on all of them.

## Sample usage : 
```
import unittest
import launch
import launch.actions
import launch_ros.actions
import launch_testing.actions
import launch_testing.markers
import pytest
import rclpy
from rclpy.node import Node
from std_msgs.msg import String

from launch_testing_ros import WaitForTopics

def generate_node(i):
    return launch_ros.actions.Node(
        executable='talker',
        package='demo_nodes_cpp',
        name='demo_node_' + str(i),
        remappings = [('chatter', 'chatter_' + str(i))]
    )

@pytest.mark.launch_test
@launch_testing.markers.keep_alive
def generate_test_description():
    # 'n' changes the number of nodes and topics
    n = 5
    description = [generate_node(i) for i in range(n)] + [launch_testing.actions.ReadyToTest()]
    return launch.LaunchDescription(description), {'count':n}

class TestFixture(unittest.TestCase):

    def test_check_if_msgs_published(self, proc_output, count):

        topic_list = [('chatter_' + str(i), String) for i in range(count)]
        with WaitForTopics(topic_list, timeout=5.0):
            print("The topics are alive !")


```
