### PR TITLE
Don't import WaitForTopics so that rclpy isn't imported

### DIFF
--- a/launch_testing_ros/launch_testing_ros/__init__.py
+++ b/launch_testing_ros/launch_testing_ros/__init__.py
@@ -17,12 +17,10 @@ from . import tools
 from .data_republisher import DataRepublisher
 from .message_pump import MessagePump
 from .test_runner import LaunchTestRunner
-from . wait_for_topics import WaitForTopics
 
 __all__ = [
     'DataRepublisher',
     'LaunchTestRunner',
     'MessagePump',
     'tools',
-    'WaitForTopics',
 ]


### PR DESCRIPTION
Might fix or workaround ros2/rclpy#831