### PR TITLE
Move pytest entrypoints to own module

### DIFF
--- a/launch_testing_ros/launch_testing_ros/pytest/hooks.py
+++ b/launch_testing_ros/launch_testing_ros/pytest/hooks.py
@@ -33,16 +33,3 @@ class LaunchROSTestModule(LaunchTestModule):
 
     def makeitem(self, *args, **kwargs):
         return LaunchROSTestItem.from_parent(*args, **kwargs)
-
-
-def pytest_launch_collect_makemodule(path, parent, entrypoint):
-    marks = getattr(entrypoint, 'pytestmark', [])
-    if marks and any(m.name == 'rostest' for m in marks):
-        return LaunchROSTestModule.from_parent(parent=parent, fspath=path)
-
-
-def pytest_configure(config):
-    config.addinivalue_line(
-        'markers',
-        'rostest: mark a generate_test_description function as a ROS launch test entrypoint'
-    )

--- a/launch_testing_ros/launch_testing_ros_pytest_entrypoint.py
+++ b/launch_testing_ros/launch_testing_ros_pytest_entrypoint.py
@@ -1,0 +1,32 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Only import standard python modules here
+# This module intentionally delays imports as late as possible to avoid
+# importing downstream modules in upstream packages when built with a merged
+# workspace.
+
+
+def pytest_launch_collect_makemodule(path, parent, entrypoint):
+    marks = getattr(entrypoint, 'pytestmark', [])
+    if marks and any(m.name == 'rostest' for m in marks):
+        from launch_testing_ros.pytest.hooks import LaunchROSTestModule
+        return LaunchROSTestModule.from_parent(parent=parent, fspath=path)
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        'markers',
+        'rostest: mark a generate_test_description function as a ROS launch test entrypoint'
+    )

--- a/launch_testing_ros/setup.py
+++ b/launch_testing_ros/setup.py
@@ -7,13 +7,14 @@ setup(
     name='launch_testing_ros',
     version='0.15.0',
     packages=find_packages(exclude=['test']),
+    py_modules=['launch_testing_ros_pytest_entrypoint'],
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/launch_testing_ros']),
         ('share/launch_testing_ros', ['package.xml']),
         ('share/launch_testing_ros/examples', glob.glob('test/examples/[!_]*.*')),
     ],
     entry_points={
-        'pytest11': ['launch_ros = launch_testing_ros.pytest.hooks'],
+        'pytest11': ['launch_ros = launch_testing_ros_pytest_entrypoint'],
     },
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
Alternative to #277 
Attempts to fix ros2/rclpy#831

This moves the pytest entrypoints to a separate module, and makes them import anything ROS specific as late as possible. This should prevent packages like `ament_package` importing downstream packages like rclpy.