### PR TITLE
Set parameters from file for composable nodes

### DIFF
--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -14,7 +14,7 @@
 
 """Module for the LoadComposableNodes action."""
 
-import os
+from pathlib import Path
 import threading
 
 from typing import List
@@ -284,8 +284,8 @@ def get_composable_node_load_request(
                 subs = normalize_parameter_dict({param[0]: param[1]})
                 parameters.append(subs)
             else:
-                param_file_path = os.path.abspath(param)
-                assert os.path.isfile(param_file_path)
+                param_file_path = Path(param).resolve()
+                assert param_file_path.is_file()
                 subs = ParameterFile(param_file_path)
                 parameters.append(subs)
     if composable_node_description.parameters is not None:

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -14,6 +14,7 @@
 
 """Module for the LoadComposableNodes action."""
 
+import os
 import threading
 
 from typing import List
@@ -35,6 +36,7 @@ from launch.utilities import ensure_argument_type
 from launch.utilities import is_a_subclass
 from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
+from launch_ros.parameter_descriptions import ParameterFile
 
 from .composable_node_container import ComposableNodeContainer
 
@@ -280,6 +282,11 @@ def get_composable_node_load_request(
         for param in params_container:
             if isinstance(param, tuple):
                 subs = normalize_parameter_dict({param[0]: param[1]})
+                parameters.append(subs)
+            else:
+                param_file_path = os.path.abspath(param)
+                assert os.path.isfile(param_file_path)
+                subs = ParameterFile(param_file_path)
                 parameters.append(subs)
     if composable_node_description.parameters is not None:
         parameters.extend(list(composable_node_description.parameters))

--- a/test_launch_ros/test/test_launch_ros/actions/test_set_parameters_from_file.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_set_parameters_from_file.py
@@ -24,6 +24,8 @@ from launch.utilities import perform_substitutions
 
 from launch_ros.actions import Node
 from launch_ros.actions import SetParameter, SetParametersFromFile
+from launch_ros.actions.load_composable_nodes import get_composable_node_load_request
+from launch_ros.descriptions import ComposableNode
 
 import yaml
 
@@ -133,4 +135,25 @@ def test_set_param_with_node():
             }
         }
 
-# TODO: (Aditya) Add test case for composable node
+
+def test_set_param_with_composable_node():
+    lc = MockContext()
+    node_description = ComposableNode(
+        package='asd',
+        plugin='my_plugin',
+        name='my_node',
+        namespace='my_ns',
+        parameters=[{'asd': 'bsd'}]
+    )
+    param_file_path = os.path.dirname(os.path.abspath(__file__)) + '/example_parameters_1.yaml'
+    set_param_1 = SetParametersFromFile(param_file_path)
+    set_param_1.execute(lc)
+    request = get_composable_node_load_request(node_description, lc)
+    parameters = request.parameters
+    assert len(parameters) == 3
+    assert parameters[0].name == 'param_1_name'
+    assert parameters[0].value.integer_value == 10
+    assert parameters[1].name == 'param_2_name'
+    assert parameters[1].value.integer_value == 20
+    assert parameters[2].name == 'asd'
+    assert parameters[2].value.string_value == 'bsd'

--- a/test_launch_ros/test/test_launch_ros/actions/test_set_parameters_from_file.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_set_parameters_from_file.py
@@ -157,3 +157,22 @@ def test_set_param_with_composable_node():
     assert parameters[1].value.integer_value == 20
     assert parameters[2].name == 'asd'
     assert parameters[2].value.string_value == 'bsd'
+
+    lc = MockContext()
+    node_description = ComposableNode(
+        package='asd',
+        plugin='my_plugin',
+        name='my_node_2',
+        namespace='my_ns',
+        parameters=[{'asd': 'bsd'}]
+    )
+    param_file_path = os.path.dirname(os.path.abspath(__file__)) + '/example_parameters_1.yaml'
+    set_param_1 = SetParametersFromFile(param_file_path)
+    set_param_1.execute(lc)
+    request = get_composable_node_load_request(node_description, lc)
+    parameters = request.parameters
+    assert len(parameters) == 2
+    assert parameters[0].name == 'param_1_name'
+    assert parameters[0].value.integer_value == 10
+    assert parameters[1].name == 'asd'
+    assert parameters[1].value.string_value == 'bsd'


### PR DESCRIPTION
This PR aims to extend the ``SetParametersFromFile`` launch action to composable nodes as well.

Sample usage :
```
import launch
from launch_ros.actions import ComposableNodeContainer
from launch_ros.descriptions import ComposableNode
from launch_ros.actions import SetParameter, SetParametersFromFile
from launch.actions import GroupAction

def generate_launch_description():
    container = ComposableNodeContainer(
            name='my_container',
            namespace='',
            package='rclcpp_components',
            executable='component_container',
            composable_node_descriptions=[
                ComposableNode(
                    package='demo_nodes_cpp',
                    plugin='demo_nodes_cpp::ParameterBlackboard',
                    name='trial',
                    parameters=[{'param_1':5}]
                )
            ],
            output='screen',
    )

    return launch.LaunchDescription([
        GroupAction(
            actions = [
                #SetParametersFromFile('./eg.yaml'),
                #SetParametersFromFile('eg.yaml'),
                SetParametersFromFile('/home/aditya/Desktop/cmp_nodes/eg.yaml'),
                SetParameter(name='param_2', value=10),
                container
            ]
        )
    ])
```

# TODO :
- Add test cases

Signed-off-by: Aditya Pande <aditya050995@gmail.com>