### PR TITLE
Handle empty strings when evaluating parameters

### DIFF
--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -71,6 +71,10 @@ def evaluate_parameter_dict(
                 # Value is a list of substitutions, so perform them to make a string
                 evaluated_value = perform_substitutions(context, list(value))
 
+                # Handle special case where yaml.safe_load will return None given an empty string
+                if len(evaluated_value) == 0:
+                    evaluated_value = "''"
+
                 try:
                     yaml_evaluated_value = yaml.safe_load(evaluated_value)
                 except yaml.YAMLError:

--- a/test_launch_ros/test/test_launch_ros/utilities/test_normalize_parameters.py
+++ b/test_launch_ros/test/test_launch_ros/utilities/test_normalize_parameters.py
@@ -396,3 +396,11 @@ def test_unallowed_yaml_types_as_strings():
     evaluate_parameters(LaunchContext(), norm)
     expected = ({'foo': 1, 'fiz': 'Text That : Cannot Be Parsed As : Yaml'},)
     assert evaluate_parameters(LaunchContext(), norm) == expected
+
+
+def test_empty_string_evalutates_to_empty_string():
+    # Regression test for https://github.com/ros2/launch_ros/pull/289#discussion_r818070166
+    orig = [{'foo': TextSubstitution(text='')}]
+    norm = normalize_parameters(orig)
+    expected = ({'foo': ''},)
+    assert evaluate_parameters(LaunchContext(), norm) == expected


### PR DESCRIPTION
If a substitution evaluates to the empty string, then yaml.safe_load() will return None, resulting
in an exception being raised. Instead, this commit allows for the empty string by first wrapping
it in an extra set of quotes before passing to yaml.safe_load().

In response to a reported regression https://github.com/ros2/launch_ros/pull/289#discussion_r818070166
if this is accepted it should be backported to Galactic and Foxy.