### PR TITLE
Use correct namespace when evaluating parameter files for composable nodes

### DIFF
--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -293,16 +293,17 @@ def get_composable_node_load_request(
     if parameters:
         request.parameters = [
             param.to_parameter_msg() for param in to_parameters_list(
-                context, request.node_name, expanded_ns,
+                context, request.node_name, combined_ns,
                 evaluate_parameters(
                     context, parameters
                 )
             )
         ]
+
     if composable_node_description.extra_arguments is not None:
         request.extra_arguments = [
             param.to_parameter_msg() for param in to_parameters_list(
-                context, request.node_name, expanded_ns,
+                context, request.node_name, combined_ns,
                 evaluate_parameters(
                     context, composable_node_description.extra_arguments
                 )

--- a/launch_ros/launch_ros/utilities/to_parameters_list.py
+++ b/launch_ros/launch_ros/utilities/to_parameters_list.py
@@ -75,7 +75,7 @@ def to_parameters_list(
     """
     parameters = []  # type: List[rclpy.parameter.Parameter]
     node_name = node_name.lstrip('/')
-    if namespace:
+    if namespace and namespace != '/':
         namespace = namespace.strip('/')
         node_name = f'{namespace}/{node_name}'
 


### PR DESCRIPTION
* When resolving parameters from a file, use the full node namespace, combined with any base
  namespace provided by launch (e.g. from PushRosNamespace).
* Handle edge case in 'to_parameters_list', when namespace equals '/'.
* Fix bug in test fixture returning invalid node names that contain consecutive forward slashes.
* Add tests to cover cases for loading parameters from file when namespace is provided by
  PushRosNamespace actions.