### PR TITLE
Increase test time tolerance

### DIFF
--- a/test_launch_ros/test/test_launch_ros/actions/test_ros_timer.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_ros_timer.py
@@ -115,7 +115,7 @@ def test_timer_action_sanity_check():
     assert shutdown_reasons[0].reason == 'One second timeout'
 
     # Verify that at least 1 sec has passed between start of test and timeout
-    tolerance = 0.25
+    tolerance = 1.0
     assert (end_time - start_time) > 1
     assert (end_time - start_time) < 1 + tolerance
 

--- a/test_launch_ros/test/test_launch_ros/actions/test_ros_timer.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_ros_timer.py
@@ -114,9 +114,9 @@ def test_timer_action_sanity_check():
     assert 0 == ls.run()
     assert shutdown_reasons[0].reason == 'One second timeout'
 
-    # Verify that 1 sec has passed between start of test and timeout
-    tolerance = 0.1
-    assert (end_time - start_time) > 1 - tolerance
+    # Verify that at least 1 sec has passed between start of test and timeout
+    tolerance = 0.25
+    assert (end_time - start_time) > 1
     assert (end_time - start_time) < 1 + tolerance
 
 


### PR DESCRIPTION
Addressing test regression on `nightly_win_deb` jobs.
https://ci.ros2.org/view/nightly/job/nightly_win_deb/2306/testReport/junit/test_launch_ros.test.test_launch_ros.actions/test_ros_timer/test_timer_action_sanity_check/

The time tolerance is currently set to 0.1 and test is failing because test_time = 1.12 > 1.1

AFAIK these type of timers make a guarantee to be triggered "at least after x amount of time". I rewrote a bit the test to reflect better this scenario. Please correct me if Iḿ wrong.


Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>