### PR TITLE
Fix importlib_metadata warning on Python 3.10.

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -561,8 +561,13 @@ def instantiate_extension(
 
 def get_extensions(logger):
     group_name = 'launch_ros.node_action'
+    entry_points_impl = importlib_metadata.entry_points()
+    if hasattr(entry_points_impl, 'select'):
+        groups = entry_points_impl.select(group=group_name)
+    else:
+        groups = entry_points_impl.get(group_name, [])
     entry_points = {}
-    for entry_point in importlib_metadata.entry_points().get(group_name, []):
+    for entry_point in groups:
         entry_points[entry_point.name] = entry_point
     extension_types = {}
     for entry_point in entry_points:


### PR DESCRIPTION
Use the newer select interface where available, but fallback
to the dict interface as needed.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Connects to https://github.com/ros2/ros2/issues/1254