### PR TITLE
Add `hz` param to `talker.py` to fix wait_for_topic_launch_test

### DIFF
--- a/launch_testing_ros/test/examples/talker.py
+++ b/launch_testing_ros/test/examples/talker.py
@@ -23,8 +23,9 @@ class Talker(Node):
     def __init__(self):
         super().__init__('talker')
         self.count = 0
+        hz_param = self.declare_parameter('hz', 1.0)
         self.publisher = self.create_publisher(String, 'chatter', 10)
-        self.timer = self.create_timer(1.0, self.callback)
+        self.timer = self.create_timer(1.0 / hz_param.value, self.callback)
 
     def callback(self):
         data = 'Hello World: {0}'.format(self.count)

--- a/launch_testing_ros/test/examples/wait_for_topic_launch_test.py
+++ b/launch_testing_ros/test/examples/wait_for_topic_launch_test.py
@@ -34,6 +34,7 @@ def generate_node(i):
         arguments=[os.path.join(path_to_test, 'talker.py')],
         name='demo_node_' + str(i),
         additional_env={'PYTHONUNBUFFERED': '1'},
+        parameters=[{'hz': 10.0}],
         remappings=[('chatter', 'chatter_' + str(i))]
     )
 


### PR DESCRIPTION
Fixes #304

The `WaitForTopics` class waits for messages to be received, not for topics to be available. While profiling the test I noticed the talker process is only publishing at 1 Hz, but the timeouts are 2 seconds. There can be a significant amount of wait time wasted because the publisher hasn't published a message since the subscriber was created. This PR fixes it by making `talker.py` publish at 10 Hz during this test. With this PR I'm unable to reproduce #304 even when running.

```
stress --cpu `nproc`
```