### PR TITLE
Support default values in parameter substitution

### DIFF
--- a/launch_ros/launch_ros/substitutions/parameter.py
+++ b/launch_ros/launch_ros/substitutions/parameter.py
@@ -91,7 +91,7 @@ class Parameter(Substitution):
     def perform(self, context: LaunchContext) -> Text:
         """Perform the substitution."""
         name = perform_substitutions(context, self.name)
-        params_container = context.launch_configurations.get('global_params', None)
+        params_container = context.launch_configurations.get('global_params', [])
         for param in params_container:
             if isinstance(param, tuple):
                 if param[0] == name:

--- a/launch_ros/launch_ros/substitutions/parameter.py
+++ b/launch_ros/launch_ros/substitutions/parameter.py
@@ -65,8 +65,7 @@ class Parameter(Substitution):
                     str_normalized_default.append(str(item))
             # use normalize_to_list_of_substitutions to convert str to TextSubstitution's too
             self.__default = \
-                normalize_to_list_of_substitutions(
-                    str_normalized_default)  # type: List[Substitution]
+                normalize_to_list_of_substitutions(str_normalized_default)
 
     @classmethod
     def parse(cls, data: Iterable[SomeSubstitutionsType]):

--- a/test_launch_ros/test/test_launch_ros/frontend/test_parameter_substitution_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_parameter_substitution_frontend.py
@@ -71,7 +71,7 @@ def check_parameter_substitution(file):
         return perform_substitutions(ls.context, substitution)
 
     # Test invalid names before declaring a parameter to check None
-    let_invalid_default, set_parameter, let, let_valid_default= ld.describe_sub_entities()
+    let_invalid_default, set_parameter, let, let_valid_default = ld.describe_sub_entities()
     assert perform(let_invalid_default.name) == 'result_default'
     assert perform(let_invalid_default.value) == 'default_value'
     assert perform(set_parameter.name) == 'name'

--- a/test_launch_ros/test/test_launch_ros/frontend/test_parameter_substitution_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_parameter_substitution_frontend.py
@@ -24,6 +24,10 @@ def test_parameter_substitution_yaml():
     yaml_file = textwrap.dedent(
         r"""
         launch:
+            - let:
+                name: result_default
+                value: $(param name-invalid default_value)
+
             - set_parameter:
                 name: name
                 value: value
@@ -35,10 +39,6 @@ def test_parameter_substitution_yaml():
             - let:
                 name: result
                 value: $(param name default_value)
-
-            - let:
-                name: result_default
-                value: $(param name-invalid default_value)
         """
     )
     with io.StringIO(yaml_file) as f:
@@ -49,10 +49,10 @@ def test_parameter_substitution_xml():
     xml_file = textwrap.dedent(
         r"""
         <launch>
+            <let name="result_default" value="$(param name-invalid default_value)" />
             <set_parameter name="name" value="value" />
             <let name="result" value="$(param name)" />
             <let name="result" value="$(param name default_value)" />
-            <let name="result_default" value="$(param name-invalid default_value)" />
         </launch>
         """
     )
@@ -70,12 +70,13 @@ def check_parameter_substitution(file):
     def perform(substitution):
         return perform_substitutions(ls.context, substitution)
 
-    set_parameter, let, let_valid_default, let_invalid_default = ld.describe_sub_entities()
+    # Test invalid names before declaring a parameter to check None
+    let_invalid_default, set_parameter, let, let_valid_default= ld.describe_sub_entities()
+    assert perform(let_invalid_default.name) == 'result_default'
+    assert perform(let_invalid_default.value) == 'default_value'
     assert perform(set_parameter.name) == 'name'
     assert perform(set_parameter.value) == 'value'
     assert perform(let.name) == 'result'
     assert perform(let.value) == 'value'
     assert perform(let_valid_default.name) == 'result'
     assert perform(let_valid_default.value) == 'value'
-    assert perform(let_invalid_default.name) == 'result_default'
-    assert perform(let_invalid_default.value) == 'default_value'

--- a/test_launch_ros/test/test_launch_ros/frontend/test_parameter_substitution_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_parameter_substitution_frontend.py
@@ -33,6 +33,10 @@ def test_parameter_substitution_yaml():
                 value: $(param name)
 
             - let:
+                name: result
+                value: $(param name default_value)
+
+            - let:
                 name: result_default
                 value: $(param name-invalid default_value)
         """
@@ -47,6 +51,7 @@ def test_parameter_substitution_xml():
         <launch>
             <set_parameter name="name" value="value" />
             <let name="result" value="$(param name)" />
+            <let name="result" value="$(param name default_value)" />
             <let name="result_default" value="$(param name-invalid default_value)" />
         </launch>
         """
@@ -65,10 +70,12 @@ def check_parameter_substitution(file):
     def perform(substitution):
         return perform_substitutions(ls.context, substitution)
 
-    set_parameter, let, let_default = ld.describe_sub_entities()
+    set_parameter, let, let_valid_default, let_invalid_default = ld.describe_sub_entities()
     assert perform(set_parameter.name) == 'name'
     assert perform(set_parameter.value) == 'value'
     assert perform(let.name) == 'result'
     assert perform(let.value) == 'value'
-    assert perform(let_default.name) == 'result_default'
-    assert perform(let_default.value) == 'default_value'
+    assert perform(let_valid_default.name) == 'result'
+    assert perform(let_valid_default.value) == 'value'
+    assert perform(let_invalid_default.name) == 'result_default'
+    assert perform(let_invalid_default.value) == 'default_value'

--- a/test_launch_ros/test/test_launch_ros/frontend/test_parameter_substitution_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_parameter_substitution_frontend.py
@@ -31,6 +31,10 @@ def test_parameter_substitution_yaml():
             - let:
                 name: result
                 value: $(param name)
+
+            - let:
+                name: result_default
+                value: $(param name-invalid default_value)
         """
     )
     with io.StringIO(yaml_file) as f:
@@ -43,6 +47,7 @@ def test_parameter_substitution_xml():
         <launch>
             <set_parameter name="name" value="value" />
             <let name="result" value="$(param name)" />
+            <let name="result_default" value="$(param name-invalid default_value)" />
         </launch>
         """
     )
@@ -60,8 +65,10 @@ def check_parameter_substitution(file):
     def perform(substitution):
         return perform_substitutions(ls.context, substitution)
 
-    set_parameter, let = ld.describe_sub_entities()
+    set_parameter, let, let_default = ld.describe_sub_entities()
     assert perform(set_parameter.name) == 'name'
     assert perform(set_parameter.value) == 'value'
     assert perform(let.name) == 'result'
     assert perform(let.value) == 'value'
+    assert perform(let_default.name) == 'result_default'
+    assert perform(let_default.value) == 'default_value'

--- a/test_launch_ros/test/test_launch_ros/substitutions/test_parameter_substitution.py
+++ b/test_launch_ros/test/test_launch_ros/substitutions/test_parameter_substitution.py
@@ -26,9 +26,13 @@ import pytest
 
 def test_parameter_substitution():
     context = LaunchContext()
-    SetParameter('name', 'value').execute(context)
-    assert Parameter('name').perform(context) == 'value'
-    assert Parameter('name', default='default_value').perform(context) == 'value'
+
+    # Test invalid names before declaring a parameter to check None
     assert Parameter('name-invalid', default='default_value').perform(context) == 'default_value'
     with pytest.raises(SubstitutionFailure):
         Parameter('name-invalid').perform(context)
+
+    # Define a parameter and check values
+    SetParameter('name', 'value').execute(context)
+    assert Parameter('name').perform(context) == 'value'
+    assert Parameter('name', default='default_value').perform(context) == 'value'

--- a/test_launch_ros/test/test_launch_ros/substitutions/test_parameter_substitution.py
+++ b/test_launch_ros/test/test_launch_ros/substitutions/test_parameter_substitution.py
@@ -28,5 +28,6 @@ def test_parameter_substitution():
     context = LaunchContext()
     SetParameter('name', 'value').execute(context)
     assert Parameter('name').perform(context) == 'value'
+    assert Parameter('name-invalid', default='default_value').perform(context) == 'default_value'
     with pytest.raises(SubstitutionFailure):
         Parameter('name-invalid').perform(context)

--- a/test_launch_ros/test/test_launch_ros/substitutions/test_parameter_substitution.py
+++ b/test_launch_ros/test/test_launch_ros/substitutions/test_parameter_substitution.py
@@ -28,6 +28,7 @@ def test_parameter_substitution():
     context = LaunchContext()
     SetParameter('name', 'value').execute(context)
     assert Parameter('name').perform(context) == 'value'
+    assert Parameter('name', default='default_value').perform(context) == 'value'
     assert Parameter('name-invalid', default='default_value').perform(context) == 'default_value'
     with pytest.raises(SubstitutionFailure):
         Parameter('name-invalid').perform(context)


### PR DESCRIPTION
I think I should have supported default values in https://github.com/ros2/launch_ros/pull/297 to be consistent with the behavior of `LaunchConfiguration`.

So I've fixed the code to be similar to https://github.com/ros2/launch/blob/d2935d6fd85636ace62699eec106cd56f5e9c6a4/launch/launch/substitutions/launch_configuration.py.