### PR TITLE
Load composable nodes in sequence

### DIFF
--- a/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
@@ -329,25 +329,31 @@ def test_load_node_with_param_file(mock_component_container):
 
     # Case 6: multiple entries (params with node name should take precedence over wildcard params)
     context = _assert_launch_no_errors([
-        _load_composable_node(
-            package='foo_package',
-            plugin='bar_plugin',
-            name='node_1',
-            namespace='ns_1',
-            parameters=[
-                parameters_file_dir / 'example_parameters_multiple_entries.yaml'
-            ],
-        ),
-        _load_composable_node(
-            package='foo_package',
-            plugin='bar_plugin',
-            name='node_2',
-            namespace='ns_2',
-            parameters=[
-                parameters_file_dir / 'example_parameters_multiple_entries.yaml'
-            ],
+        LoadComposableNodes(  # Load in same action so it happens sequentially
+            target_container=f'/{TEST_CONTAINER_NAME}',
+            composable_node_descriptions=[
+                ComposableNode(
+                    package='foo_package',
+                    plugin='bar_plugin',
+                    name='node_1',
+                    namespace='ns_1',
+                    parameters=[
+                        parameters_file_dir / 'example_parameters_multiple_entries.yaml'
+                    ]
+                ),
+                ComposableNode(
+                    package='foo_package',
+                    plugin='bar_plugin',
+                    name='node_2',
+                    namespace='ns_2',
+                    parameters=[
+                        parameters_file_dir / 'example_parameters_multiple_entries.yaml'
+                    ]
+                )
+            ]
         )
     ])
+
     request = mock_component_container.requests[-2]
     assert get_node_name_count(context, '/ns_1/node_1') == 1
     assert request.node_name == 'node_1'


### PR DESCRIPTION
Fixes #312 

Each `_load_composable_node` function creates its own `LoadComposableNodes` action. When there are multiple `LoadComposableNodes` actions it appears possible for them to load the nodes in a different order from the launch description.

I think this is happening because the actual loading is passed to [asyncio's `run_in_executor()`'](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_in_executor) method. The docs say [this uses a `concurrent.futures.ThreadPoolExecutor`](https://docs.python.org/3/library/concurrent.futures.html#threadpoolexecutor-example), so the order nodes get loaded depends on the scheduling of the threads in the executor.

This PR fixes the test by loading both composable nodes in the same `LoadComposableNodes` action. This works because it explicitly [loads the composable nodes in sequence](https://github.com/ros2/launch_ros/blob/d3970e5aa46b1449228f2d01d6b9e05555637d82/launch_ros/launch_ros/actions/load_composable_nodes.py#L70).