### PR TITLE
Improve evaluate_paramenter_dict exceptions error message

### DIFF
--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -93,16 +93,20 @@ def evaluate_parameter_dict(
                     if not check_sequence_type_is_allowed(yaml_evaluated_value):
                         raise TypeError(
                             'Expected a non-empty sequence, with items of uniform type. '
-                            'Allowed sequence item types are bool, int, float, str.'
+                            'Allowed sequence item types are bool, int, float, str. '
+                            'Got inconsistent input for "{}"'.format(evaluated_name)
                         )
                     evaluated_value = tuple(yaml_evaluated_value)
                 else:
                     raise TypeError(
                         'Allowed value types are bytes, bool, int, float, str, Sequence[bool]'
-                        ', Sequence[int], Sequence[float], Sequence[str]. Got {}.'
+                        ', Sequence[int], Sequence[float], Sequence[str]. Got {} for "{}". '
                         'If the parameter is meant to be a string, try wrapping it in '
                         'launch_ros.parameter_descriptions.ParameterValue'
-                        '(value, value_type=str)'.format(type(yaml_evaluated_value))
+                        '(value, value_type=str)'.format(
+                            type(yaml_evaluated_value),
+                            evaluated_name
+                        )
                     )
             elif isinstance(value[0], Sequence):
                 # Value is an array of a list of substitutions
@@ -119,7 +123,8 @@ def evaluate_parameter_dict(
                 if not check_sequence_type_is_allowed(yaml_evaluated_value):
                     raise TypeError(
                         'Expected a non-empty sequence, with items of uniform type. '
-                        'Allowed sequence item types are bool, int, float, str.'
+                        'Allowed sequence item types are bool, int, float, str. '
+                        'Got inconsistent input for "{}"'.format(evaluated_name)
                     )
                 evaluated_value = tuple(yaml_evaluated_value)
             else:


### PR DESCRIPTION
This PR updates the `evaluate_paramenter_dict()` possible exceptions adding the name of the parameter that caused the exception, thus helping find the root of the problem when it occurs

For example, if a `NoneType` argument is passed to the function, the thrown message would be

```
TypeError: Allowed value types are bytes, bool, int, float, str, Sequence[bool], Sequence[int], 
Sequence[float], Sequence[str]. Got <class 'NoneType'>. If the parameter is meant to be 
a string, try wrapping it in launch_ros.parameter_descriptions.ParameterValue(value, value_type=str)
```

Within a large project, with dozens of launch arguments, it is not trivial to discover which argument received the invalid value. As the name of the argument being evaluated is already available in the scope of the exception, adding it to the error message would be really helpful when dealing with this problem.

As discussed in some ROS 2 tickets (https://github.com/ros2/launch_ros/issues/291, https://github.com/ros2/launch/issues/412), one of the main issues of the launch system is the lack of helpful information when something goes wrong, this PR is a small step in the direction of solving this issue