### PR TITLE
add SetROSLogDir action

### DIFF
--- a/launch_ros/launch_ros/actions/__init__.py
+++ b/launch_ros/launch_ros/actions/__init__.py
@@ -23,6 +23,7 @@ from .ros_timer import RosTimer
 from .set_parameter import SetParameter
 from .set_parameters_from_file import SetParametersFromFile
 from .set_remap import SetRemap
+from .set_ros_log_dir import SetROSLogDir
 from .set_use_sim_time import SetUseSimTime
 
 
@@ -36,5 +37,6 @@ __all__ = [
     'SetParameter',
     'SetParametersFromFile',
     'SetRemap',
+    'SetROSLogDir',
     'SetUseSimTime'
 ]

--- a/launch_ros/launch_ros/actions/__init__.py
+++ b/launch_ros/launch_ros/actions/__init__.py
@@ -23,7 +23,7 @@ from .ros_timer import RosTimer
 from .set_parameter import SetParameter
 from .set_parameters_from_file import SetParametersFromFile
 from .set_remap import SetRemap
-from .set_ros_log_dir import SetROSLogDir
+from .set_ros_log_dir import SetRosLogDir
 from .set_use_sim_time import SetUseSimTime
 
 
@@ -37,6 +37,6 @@ __all__ = [
     'SetParameter',
     'SetParametersFromFile',
     'SetRemap',
-    'SetROSLogDir',
+    'SetRosLogDir',
     'SetUseSimTime'
 ]

--- a/launch_ros/launch_ros/actions/__init__.py
+++ b/launch_ros/launch_ros/actions/__init__.py
@@ -23,7 +23,7 @@ from .ros_timer import RosTimer
 from .set_parameter import SetParameter
 from .set_parameters_from_file import SetParametersFromFile
 from .set_remap import SetRemap
-from .set_ros_log_dir import SetRosLogDir
+from .set_ros_log_dir import SetROSLogDir
 from .set_use_sim_time import SetUseSimTime
 
 
@@ -37,6 +37,6 @@ __all__ = [
     'SetParameter',
     'SetParametersFromFile',
     'SetRemap',
-    'SetRosLogDir',
+    'SetROSLogDir',
     'SetUseSimTime'
 ]

--- a/launch_ros/launch_ros/actions/set_ros_log_dir.py
+++ b/launch_ros/launch_ros/actions/set_ros_log_dir.py
@@ -17,8 +17,6 @@
 import os
 from typing import List
 
-from rclpy.logging import get_logging_directory
-
 from launch import Action
 from launch import Substitution
 from launch.frontend import Entity
@@ -28,6 +26,7 @@ from launch.launch_context import LaunchContext
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
+from rclpy.logging import get_logging_directory
 
 
 @expose_action('set_ros_log_dir')

--- a/launch_ros/launch_ros/actions/set_ros_log_dir.py
+++ b/launch_ros/launch_ros/actions/set_ros_log_dir.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module for the `SetRosLogDir` action."""
+"""Module for the `SetROSLogDir` action."""
 
 import os
 from typing import List
@@ -31,7 +31,7 @@ from launch.utilities import perform_substitutions
 
 
 @expose_action('set_ros_log_dir')
-class SetRosLogDir(Action):
+class SetROSLogDir(Action):
     """
     Action that sets the ros log directory.
 
@@ -52,7 +52,7 @@ class SetRosLogDir(Action):
         **kwargs
     ) -> None:
         """
-        Create a SetRosLogDir action.
+        Create a SetROSLogDir action.
 
         :param new_log_dir: new log directory, if absolute it sets the ros log dir,
             but if it is a relative path, then it is joined with the current ros log dir.
@@ -62,7 +62,7 @@ class SetRosLogDir(Action):
 
     @classmethod
     def parse(cls, entity: Entity, parser: Parser):
-        """Return `SetRosLogDir` action and kwargs for constructing it."""
+        """Return `SetROSLogDir` action and kwargs for constructing it."""
         _, kwargs = super().parse(entity, parser)
         kwargs['new_log_dir'] = parser.parse_substitution(entity.get_attr('new_log_dir'))
         return cls, kwargs

--- a/launch_ros/launch_ros/actions/set_ros_log_dir.py
+++ b/launch_ros/launch_ros/actions/set_ros_log_dir.py
@@ -1,0 +1,84 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the `SetROSLogDir` action."""
+
+import os
+from typing import List
+
+from rclpy.logging import get_logging_directory
+
+from launch import Action
+from launch import Substitution
+from launch.frontend import Entity
+from launch.frontend import expose_action
+from launch.frontend import Parser
+from launch.launch_context import LaunchContext
+from launch.some_substitutions_type import SomeSubstitutionsType
+from launch.utilities import normalize_to_list_of_substitutions
+from launch.utilities import perform_substitutions
+
+
+@expose_action('set_ros_log_dir')
+class SetROSLogDir(Action):
+    """
+    Action that sets the ros log directory.
+
+    This is done by setting the ROS_LOG_DIR environment variable, which will
+    influence all processes started after that time, in which ros was initialized.
+
+    This can be used in combination with launch.actions.GroupAction and its
+    ``scoped=true`` option to provide scoped changes to this environment
+    variable.
+
+    Note this will not affect nodes loaded into component containers which were
+    started before this action is executed.
+    """
+
+    def __init__(
+        self,
+        new_log_dir: SomeSubstitutionsType,
+        **kwargs
+    ) -> None:
+        """
+        Create a SetROSLogDir action.
+
+        :param new_log_dir: new log directory, if absolute it sets the ros log dir,
+            but if it is a relative path, then it is joined with the current ros log dir.
+        """
+        super().__init__(**kwargs)
+        self.__log_dir = normalize_to_list_of_substitutions(new_log_dir)
+
+    @classmethod
+    def parse(cls, entity: Entity, parser: Parser):
+        """Return `SetROSLogDir` action and kwargs for constructing it."""
+        _, kwargs = super().parse(entity, parser)
+        kwargs['new_log_dir'] = parser.parse_substitution(entity.get_attr('new_log_dir'))
+        return cls, kwargs
+
+    @property
+    def log_dir(self) -> List[Substitution]:
+        """Getter for self.__log_dir."""
+        return self.__log_dir
+
+    def execute(self, context: LaunchContext):
+        """Execute the action."""
+        new_log_dir = perform_substitutions(context, self.log_dir)
+        current_rclpy_logging_directory = get_logging_directory()
+        # Prefer ROS_LOG_DIR over what rclpy reports, but fall back to that if not set.
+        current_log_dir = os.environ.get('ROS_LOG_DIR', current_rclpy_logging_directory)
+        # If new_log_dir is abs, then current_log_dir will be truncated and not used.
+        log_dir = os.path.join(current_log_dir, new_log_dir)
+        assert os.path.isabs(log_dir)
+        os.environ['ROS_LOG_DIR'] = log_dir

--- a/launch_ros/launch_ros/actions/set_ros_log_dir.py
+++ b/launch_ros/launch_ros/actions/set_ros_log_dir.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module for the `SetROSLogDir` action."""
+"""Module for the `SetRosLogDir` action."""
 
 import os
 from typing import List
@@ -31,7 +31,7 @@ from launch.utilities import perform_substitutions
 
 
 @expose_action('set_ros_log_dir')
-class SetROSLogDir(Action):
+class SetRosLogDir(Action):
     """
     Action that sets the ros log directory.
 
@@ -52,7 +52,7 @@ class SetROSLogDir(Action):
         **kwargs
     ) -> None:
         """
-        Create a SetROSLogDir action.
+        Create a SetRosLogDir action.
 
         :param new_log_dir: new log directory, if absolute it sets the ros log dir,
             but if it is a relative path, then it is joined with the current ros log dir.
@@ -62,7 +62,7 @@ class SetROSLogDir(Action):
 
     @classmethod
     def parse(cls, entity: Entity, parser: Parser):
-        """Return `SetROSLogDir` action and kwargs for constructing it."""
+        """Return `SetRosLogDir` action and kwargs for constructing it."""
         _, kwargs = super().parse(entity, parser)
         kwargs['new_log_dir'] = parser.parse_substitution(entity.get_attr('new_log_dir'))
         return cls, kwargs

--- a/test_launch_ros/test/test_launch_ros/actions/test_set_ros_log_dir.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_set_ros_log_dir.py
@@ -1,0 +1,75 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the SetROSLogDir Action."""
+
+import io
+import os
+import textwrap
+
+from launch import LaunchContext
+from launch.actions import PopEnvironment
+from launch.actions import PushEnvironment
+from launch.frontend import Parser
+
+from launch_ros.actions import SetROSLogDir
+
+
+def test_set_ros_log_dir_constructor():
+    """Test the constructor for SetROSLogDir class."""
+    SetROSLogDir(new_log_dir='')
+
+
+def test_set_ros_log_dir_relative(tmpdir):
+    """Test adding a relative path to the ROS log dir."""
+    lc = LaunchContext()
+
+    PushEnvironment().visit(lc)
+    try:
+        initial_ros_log_dir = os.path.join(tmpdir, 'test_ros_log_dir')
+        os.environ['ROS_LOG_DIR'] = initial_ros_log_dir
+        SetROSLogDir('relative').visit(lc)
+        assert os.environ['ROS_LOG_DIR'] == os.path.join(initial_ros_log_dir, 'relative')
+    finally:
+        PopEnvironment().visit(lc)
+
+
+def test_set_ros_log_dir_absolute(tmpdir):
+    """Test setting an absolute path to the ROS log dir."""
+    lc = LaunchContext()
+
+    PushEnvironment().visit(lc)
+    try:
+        initial_ros_log_dir = os.path.join(tmpdir, 'test_ros_log_dir')
+        os.environ['ROS_LOG_DIR'] = initial_ros_log_dir
+        new_ros_log_dir = os.path.join(tmpdir, 'test_set_ros_log_dir_absolute')
+        SetROSLogDir(new_ros_log_dir).visit(lc)
+        assert os.environ['ROS_LOG_DIR'] == new_ros_log_dir
+    finally:
+        PopEnvironment().visit(lc)
+
+
+def test_set_ros_log_dir_frontend():
+    """Test the frontend parsing of SetROSLogDir."""
+    xml_file = textwrap.dedent(r"""
+        <launch>
+            <set_ros_log_dir new_log_dir="relative" />
+        </launch>
+    """)
+
+    with io.StringIO(xml_file) as f:
+        root_entity, parser = Parser.load(f)
+        ld = parser.parse_description(root_entity)
+        assert len(ld.entities) == 1
+        assert isinstance(ld.entities[0], SetROSLogDir)

--- a/test_launch_ros/test/test_launch_ros/actions/test_set_ros_log_dir.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_set_ros_log_dir.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the SetROSLogDir Action."""
+"""Tests for the SetRosLogDir Action."""
 
 import io
 import os
@@ -23,12 +23,12 @@ from launch.actions import PopEnvironment
 from launch.actions import PushEnvironment
 from launch.frontend import Parser
 
-from launch_ros.actions import SetROSLogDir
+from launch_ros.actions import SetRosLogDir
 
 
 def test_set_ros_log_dir_constructor():
-    """Test the constructor for SetROSLogDir class."""
-    SetROSLogDir(new_log_dir='')
+    """Test the constructor for SetRosLogDir class."""
+    SetRosLogDir(new_log_dir='')
 
 
 def test_set_ros_log_dir_relative(tmpdir):
@@ -39,7 +39,7 @@ def test_set_ros_log_dir_relative(tmpdir):
     try:
         initial_ros_log_dir = os.path.join(tmpdir, 'test_ros_log_dir')
         os.environ['ROS_LOG_DIR'] = initial_ros_log_dir
-        SetROSLogDir('relative').visit(lc)
+        SetRosLogDir('relative').visit(lc)
         assert os.environ['ROS_LOG_DIR'] == os.path.join(initial_ros_log_dir, 'relative')
     finally:
         PopEnvironment().visit(lc)
@@ -54,14 +54,14 @@ def test_set_ros_log_dir_absolute(tmpdir):
         initial_ros_log_dir = os.path.join(tmpdir, 'test_ros_log_dir')
         os.environ['ROS_LOG_DIR'] = initial_ros_log_dir
         new_ros_log_dir = os.path.join(tmpdir, 'test_set_ros_log_dir_absolute')
-        SetROSLogDir(new_ros_log_dir).visit(lc)
+        SetRosLogDir(new_ros_log_dir).visit(lc)
         assert os.environ['ROS_LOG_DIR'] == new_ros_log_dir
     finally:
         PopEnvironment().visit(lc)
 
 
 def test_set_ros_log_dir_frontend():
-    """Test the frontend parsing of SetROSLogDir."""
+    """Test the frontend parsing of SetRosLogDir."""
     xml_file = textwrap.dedent(r"""
         <launch>
             <set_ros_log_dir new_log_dir="relative" />
@@ -72,4 +72,4 @@ def test_set_ros_log_dir_frontend():
         root_entity, parser = Parser.load(f)
         ld = parser.parse_description(root_entity)
         assert len(ld.entities) == 1
-        assert isinstance(ld.entities[0], SetROSLogDir)
+        assert isinstance(ld.entities[0], SetRosLogDir)

--- a/test_launch_ros/test/test_launch_ros/actions/test_set_ros_log_dir.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_set_ros_log_dir.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the SetRosLogDir Action."""
+"""Tests for the SetROSLogDir Action."""
 
 import io
 import os
@@ -23,12 +23,12 @@ from launch.actions import PopEnvironment
 from launch.actions import PushEnvironment
 from launch.frontend import Parser
 
-from launch_ros.actions import SetRosLogDir
+from launch_ros.actions import SetROSLogDir
 
 
 def test_set_ros_log_dir_constructor():
-    """Test the constructor for SetRosLogDir class."""
-    SetRosLogDir(new_log_dir='')
+    """Test the constructor for SetROSLogDir class."""
+    SetROSLogDir(new_log_dir='')
 
 
 def test_set_ros_log_dir_relative(tmpdir):
@@ -39,7 +39,7 @@ def test_set_ros_log_dir_relative(tmpdir):
     try:
         initial_ros_log_dir = os.path.join(tmpdir, 'test_ros_log_dir')
         os.environ['ROS_LOG_DIR'] = initial_ros_log_dir
-        SetRosLogDir('relative').visit(lc)
+        SetROSLogDir('relative').visit(lc)
         assert os.environ['ROS_LOG_DIR'] == os.path.join(initial_ros_log_dir, 'relative')
     finally:
         PopEnvironment().visit(lc)
@@ -54,14 +54,14 @@ def test_set_ros_log_dir_absolute(tmpdir):
         initial_ros_log_dir = os.path.join(tmpdir, 'test_ros_log_dir')
         os.environ['ROS_LOG_DIR'] = initial_ros_log_dir
         new_ros_log_dir = os.path.join(tmpdir, 'test_set_ros_log_dir_absolute')
-        SetRosLogDir(new_ros_log_dir).visit(lc)
+        SetROSLogDir(new_ros_log_dir).visit(lc)
         assert os.environ['ROS_LOG_DIR'] == new_ros_log_dir
     finally:
         PopEnvironment().visit(lc)
 
 
 def test_set_ros_log_dir_frontend():
-    """Test the frontend parsing of SetRosLogDir."""
+    """Test the frontend parsing of SetROSLogDir."""
     xml_file = textwrap.dedent(r"""
         <launch>
             <set_ros_log_dir new_log_dir="relative" />
@@ -72,4 +72,4 @@ def test_set_ros_log_dir_frontend():
         root_entity, parser = Parser.load(f)
         ld = parser.parse_description(root_entity)
         assert len(ld.entities) == 1
-        assert isinstance(ld.entities[0], SetRosLogDir)
+        assert isinstance(ld.entities[0], SetROSLogDir)


### PR DESCRIPTION
This action can be used to change the ROS log dir for any processes started after this action that contain ROS nodes.

It can be scoped when used in conjunction with the `launch.actions.GroupAction` action.

Requires https://github.com/ros2/launch/pull/652