### PR TITLE
RosTimer -> ROSTimer and PushRosNamespace -> PushROSNamespace, to follow PEP8

### DIFF
--- a/launch_ros/launch_ros/actions/__init__.py
+++ b/launch_ros/launch_ros/actions/__init__.py
@@ -18,8 +18,10 @@ from .composable_node_container import ComposableNodeContainer
 from .lifecycle_node import LifecycleNode
 from .load_composable_nodes import LoadComposableNodes
 from .node import Node
-from .push_ros_namespace import PushRosNamespace
-from .ros_timer import RosTimer
+from .push_ros_namespace import PushROSNamespace
+from .push_ros_namespace import PushROSNamespace as PushRosNamespace
+from .ros_timer import ROSTimer
+from .ros_timer import ROSTimer as RosTimer
 from .set_parameter import SetParameter
 from .set_parameters_from_file import SetParametersFromFile
 from .set_remap import SetRemap
@@ -31,7 +33,9 @@ __all__ = [
     'LifecycleNode',
     'LoadComposableNodes',
     'Node',
+    'PushROSNamespace',
     'PushRosNamespace',
+    'ROSTimer',
     'RosTimer',
     'SetParameter',
     'SetParametersFromFile',

--- a/launch_ros/launch_ros/actions/push_ros_namespace.py
+++ b/launch_ros/launch_ros/actions/push_ros_namespace.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module for the `PushRosNamespace` action."""
+"""Module for the `PushROSNamespace` action."""
 
 from typing import List
 
@@ -35,7 +35,7 @@ from rclpy.validate_namespace import validate_namespace
 
 @expose_action('push_ros_namespace')
 @expose_action('push-ros-namespace')
-class PushRosNamespace(Action):
+class PushROSNamespace(Action):
     """
     Action that pushes the ros namespace.
 
@@ -48,13 +48,13 @@ class PushRosNamespace(Action):
         namespace: SomeSubstitutionsType,
         **kwargs
     ) -> None:
-        """Create a PushRosNamespace action."""
+        """Create a PushROSNamespace action."""
         super().__init__(**kwargs)
         self.__namespace = normalize_to_list_of_substitutions(namespace)
 
     @classmethod
     def parse(cls, entity: Entity, parser: Parser):
-        """Return `PushRosNamespace` action and kwargs for constructing it."""
+        """Return `PushROSNamespace` action and kwargs for constructing it."""
         _, kwargs = super().parse(entity, parser)
         kwargs['namespace'] = parser.parse_substitution(entity.get_attr('namespace'))
         return cls, kwargs

--- a/launch_ros/launch_ros/actions/ros_timer.py
+++ b/launch_ros/launch_ros/actions/ros_timer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module for the RosTimer action."""
+"""Module for the ROSTimer action."""
 
 import asyncio
 import collections.abc
@@ -39,7 +39,7 @@ from launch_ros.ros_adapters import get_ros_node
 
 
 @expose_action('ros_timer')
-class RosTimer(TimerAction):
+class ROSTimer(TimerAction):
     """
     Action that defers other entities until a period of time has passed, unless canceled.
 
@@ -56,15 +56,15 @@ class RosTimer(TimerAction):
         **kwargs
     ) -> None:
         """
-        Create a RosTimer.
+        Create a ROSTimer.
 
         :param period: is the time (in seconds) to set the timer for.
         :param actions: is an iterable containing actions to be executed upon on timeout.
         """
         super().__init__(period=period, actions=actions, **kwargs)
         period_types = list(SomeSubstitutionsType_types_tuple) + [float]
-        ensure_argument_type(period, period_types, 'period', 'RosTimer')
-        ensure_argument_type(actions, collections.abc.Iterable, 'actions', 'RosTimer')
+        ensure_argument_type(period, period_types, 'period', 'ROSTimer')
+        ensure_argument_type(actions, collections.abc.Iterable, 'actions', 'ROSTimer')
         self.__period = type_utils.normalize_typed_substitution(period, float)
         self.__timer_future: Optional[asyncio.Future] = None
 
@@ -94,7 +94,7 @@ class RosTimer(TimerAction):
         entity: Entity,
         parser: Parser,
     ):
-        """Return the `RosTimer` action and kwargs for constructing it."""
+        """Return the `ROSTimer` action and kwargs for constructing it."""
         _, kwargs = super().parse(entity, parser)
         kwargs['period'] = parser.parse_if_substitutions(
             entity.get_attr('period', data_type=float, can_be_str=True))
@@ -102,8 +102,8 @@ class RosTimer(TimerAction):
         return cls, kwargs
 
     def describe(self) -> Text:
-        """Return a description of this RosTimer."""
-        return 'RosTimer(period={}, actions=<actions>)'.format(self.__period)
+        """Return a description of this ROSTimer."""
+        return 'ROSTimer(period={}, actions=<actions>)'.format(self.__period)
 
     def execute(self, context: LaunchContext):
         self.__timer_future = create_future(context.asyncio_loop)

--- a/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
@@ -23,7 +23,7 @@ from launch import LaunchDescription
 from launch import LaunchService
 from launch.actions import GroupAction
 from launch_ros.actions import LoadComposableNodes
-from launch_ros.actions import PushRosNamespace
+from launch_ros.actions import PushROSNamespace
 from launch_ros.actions import SetRemap
 from launch_ros.descriptions import ComposableNode
 from launch_ros.utilities import get_node_name_count
@@ -414,7 +414,7 @@ def test_load_node_with_param_file(mock_component_container):
     # Node name with namespace from launch
     # Params file has no namespace
     context = _assert_launch_no_errors([
-        PushRosNamespace('ns'),
+        PushROSNamespace('ns'),
         _load_composable_node(
             package='foo_package',
             plugin='bar_plugin',
@@ -433,7 +433,7 @@ def test_load_node_with_param_file(mock_component_container):
     # Node name with namespace from launch
     # Params file has expected namespace
     context = _assert_launch_no_errors([
-        PushRosNamespace('ns'),
+        PushROSNamespace('ns'),
         _load_composable_node(
             package='foo_package',
             plugin='bar_plugin',
@@ -490,7 +490,7 @@ def test_load_node_with_namespace_in_group(mock_component_container):
     context = _assert_launch_no_errors([
         GroupAction(
             [
-                PushRosNamespace('foo'),
+                PushROSNamespace('foo'),
                 _load_composable_node(
                     package='foo_package',
                     plugin='bar_plugin',

--- a/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the PushRosNamespace Action."""
+"""Tests for the PushROSNamespace Action."""
 
 from launch_ros.actions import Node
-from launch_ros.actions import PushRosNamespace
+from launch_ros.actions import PushROSNamespace
 from launch_ros.actions.load_composable_nodes import get_composable_node_load_request
 from launch_ros.descriptions import ComposableNode
 
@@ -105,10 +105,10 @@ def get_test_cases():
 def test_push_ros_namespace(config):
     lc = MockContext()
     if config.push_ns is not None:
-        pns1 = PushRosNamespace(config.push_ns)
+        pns1 = PushROSNamespace(config.push_ns)
         pns1.execute(lc)
     if config.second_push_ns is not None:
-        pns2 = PushRosNamespace(config.second_push_ns)
+        pns2 = PushROSNamespace(config.second_push_ns)
         pns2.execute(lc)
     node = Node(
         package='dont_care',
@@ -132,10 +132,10 @@ def test_push_ros_namespace(config):
 def test_push_ros_namespace_with_composable_node(config):
     lc = MockContext()
     if config.push_ns is not None:
-        pns1 = PushRosNamespace(config.push_ns)
+        pns1 = PushROSNamespace(config.push_ns)
         pns1.execute(lc)
     if config.second_push_ns is not None:
-        pns2 = PushRosNamespace(config.second_push_ns)
+        pns2 = PushROSNamespace(config.second_push_ns)
         pns2.execute(lc)
     node_description = ComposableNode(
         package='asd',

--- a/test_launch_ros/test/test_launch_ros/actions/test_ros_timer.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_ros_timer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-"""Tests for the RosTimer Action."""
+"""Tests for the ROSTimer Action."""
 from functools import partial
 import threading
 import time
@@ -23,7 +23,7 @@ import launch
 from launch.actions import DeclareLaunchArgument
 import launch.event_handlers
 from launch.substitutions import LaunchConfiguration
-from launch_ros.actions import RosTimer
+from launch_ros.actions import ROSTimer
 from launch_ros.actions import SetUseSimTime
 import pytest
 import rclpy
@@ -57,7 +57,7 @@ def test_multiple_launch_with_timers():
     def generate_launch_description():
         return launch.LaunchDescription([
 
-            RosTimer(
+            ROSTimer(
                 period=1.,
                 actions=[]
             ),
@@ -76,7 +76,7 @@ def test_timer_with_launch_configuration():
     def generate_launch_description():
         return launch.LaunchDescription([
             DeclareLaunchArgument('my_period', default_value='0.1'),
-            RosTimer(
+            ROSTimer(
                 period=LaunchConfiguration('my_period'),
                 actions=[]
             ),
@@ -98,7 +98,7 @@ def test_timer_action_sanity_check():
 
         launch.actions.OpaqueFunction(function=set_start_time),
 
-        RosTimer(
+        ROSTimer(
             period=1.,
             actions=[
                 launch.actions.OpaqueFunction(function=set_end_time),
@@ -125,14 +125,14 @@ def test_shutdown_preempts_timers():
 
     ld = launch.LaunchDescription([
 
-        RosTimer(
+        ROSTimer(
             period=1.,
             actions=[
                 launch.actions.Shutdown(reason='fast shutdown')
             ]
         ),
 
-        RosTimer(
+        ROSTimer(
             period=2.,
             actions=[
                 launch.actions.Shutdown(reason='slow shutdown')
@@ -179,7 +179,7 @@ def test_timer_uses_sim_time(rclpy_node):
 
         launch.actions.OpaqueFunction(function=set_start_time),
 
-        RosTimer(
+        ROSTimer(
             period=200.,
             actions=[
                 launch.actions.OpaqueFunction(function=set_end_time)


### PR DESCRIPTION
Follow up of https://github.com/ros2/launch_ros/pull/325#discussion_r979069795

I didn't actually see these being used anywhere else in the standard ROS repositories. But I did find a few places in the documentation: https://github.com/ros2/ros2_documentation/pull/3038