### PR TITLE
Fix "imported but not used" linters

### DIFF
--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -18,6 +18,7 @@ import threading
 
 from typing import List
 from typing import Optional
+from typing import Text # noqa
 from typing import Union
 
 import composition_interfaces.srv

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -18,7 +18,6 @@ import threading
 
 from typing import List
 from typing import Optional
-from typing import Text
 from typing import Union
 
 import composition_interfaces.srv

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -18,7 +18,7 @@ import threading
 
 from typing import List
 from typing import Optional
-from typing import Text # noqa
+from typing import Text  # noqa: F401
 from typing import Union
 
 import composition_interfaces.srv

--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -17,7 +17,6 @@
 
 from collections.abc import Mapping
 from collections.abc import Sequence
-import pathlib
 from typing import cast
 from typing import Dict
 from typing import List

--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -17,7 +17,7 @@
 
 from collections.abc import Mapping
 from collections.abc import Sequence
-import pathlib # noqa
+import pathlib  # noqa: F401
 from typing import cast
 from typing import Dict
 from typing import List

--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -17,6 +17,7 @@
 
 from collections.abc import Mapping
 from collections.abc import Sequence
+import pathlib # noqa
 from typing import cast
 from typing import Dict
 from typing import List


### PR DESCRIPTION
These linter errors started showing in the Galactic coverage jobs three days ago, reference job:
https://ci.ros2.org/job/nightly_linux_galactic_coverage/585/

As it was a quick one, I decided to open a PR to fix it. PTAL @Crola1702 @cottsay 

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>