### PR TITLE
fix: return text value to avoid exception (#338)

### DIFF
--- a/launch_ros/launch_ros/substitutions/parameter.py
+++ b/launch_ros/launch_ros/substitutions/parameter.py
@@ -68,5 +68,5 @@ class Parameter(Substitution):
         for param in params_container:
             if isinstance(param, tuple):
                 if param[0] == name:
-                    return param[1]
+                    return str(param[1])
         raise SubstitutionFailure("parameter '{}' not found".format(name))


### PR DESCRIPTION
I think #338 is a bug fix, so I would like to backport the change into humble.