### PR TITLE
Implement None check for ComposableNodeContainer

### DIFF
--- a/launch_ros/launch_ros/actions/composable_node_container.py
+++ b/launch_ros/launch_ros/actions/composable_node_container.py
@@ -80,9 +80,11 @@ class ComposableNodeContainer(Node):
         """
         load_actions = None  # type: Optional[List[Action]]
         valid_composable_nodes = []
-        for node_object in self.__composable_node_descriptions:
-            if node_object.condition() is None or node_object.condition().evaluate(context):
-                valid_composable_nodes.append(node_object)
+        if self.__composable_node_descriptions:
+            for node_object in self.__composable_node_descriptions:
+                if node_object.condition() is None or node_object.condition().evaluate(context):
+                    valid_composable_nodes.append(node_object)
+
         if (
             valid_composable_nodes is not None and
             len(valid_composable_nodes) > 0

--- a/test_launch_ros/test/test_launch_ros/actions/test_composable_node_container.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_composable_node_container.py
@@ -89,6 +89,22 @@ def test_composable_node_container_empty_list_of_nodes():
     assert get_node_name_count(context, f'/{TEST_NODE_NAMESPACE}/{TEST_NODE_NAME}') == 0
 
 
+def test_composable_node_container_no_list_of_nodes():
+    """Test launching a ComposableNodeContainer with no passed in list of nodes."""
+    actions = [
+        ComposableNodeContainer(
+            package='rclcpp_components',
+            executable='component_container',
+            name=TEST_CONTAINER_NAME,
+            namespace=TEST_CONTAINER_NAMESPACE
+        ),
+    ]
+
+    context = _assert_launch_no_errors(actions)
+    assert get_node_name_count(context, f'/{TEST_CONTAINER_NAMESPACE}/{TEST_CONTAINER_NAME}') == 1
+    assert get_node_name_count(context, f'/{TEST_NODE_NAMESPACE}/{TEST_NODE_NAME}') == 0
+
+
 def test_composable_node_container_in_group_with_launch_configuration_in_description():
     """
     Test launch configuration is passed to ComposableNode description inside GroupAction.


### PR DESCRIPTION
This lets you pass in no list of nodes for ComposableNodeContainer so you can do this:

```
    container = ComposableNodeContainer(
        package='rclcpp_components',
        executable='component_container',
        name=TEST_CONTAINER_NAME,
        namespace=TEST_CONTAINER_NAMESPACE
)
```

And so you can then pass that container to a subsequent LoadComposableNode call, if you wanted to.

Currently you would have to explicitly pass an empty list. But in that case, I'm not sure why the default argument in the constructor would be None as opposed to an empty list. (I think supporting both cases in this case would be preferable.)