### PR TITLE
Enable to pass additional environment variables to node

### DIFF
--- a/launch_ros/launch_ros/actions/composable_node_container.py
+++ b/launch_ros/launch_ros/actions/composable_node_container.py
@@ -14,6 +14,7 @@
 
 """Module for the ComposableNodeContainer action."""
 
+from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -39,6 +40,7 @@ class ComposableNodeContainer(Node):
         name: SomeSubstitutionsType,
         namespace: SomeSubstitutionsType,
         composable_node_descriptions: Optional[List[ComposableNode]] = None,
+        additional_env: Optional[Dict[SomeSubstitutionsType, SomeSubstitutionsType]] = None,
         **kwargs
     ) -> None:
         """
@@ -51,8 +53,9 @@ class ComposableNodeContainer(Node):
         :param: namespace the ROS namespace for this Node, mandatory for full container node
              name resolution
         :param composable_node_descriptions: optional descriptions of composable nodes to be loaded
+        :param additional_env: dictionary of environment variables to be added.
         """
-        super().__init__(name=name, namespace=namespace, **kwargs)
+        super().__init__(name=name, namespace=namespace, additional_env=additional_env, **kwargs)
         self.__composable_node_descriptions = composable_node_descriptions
 
     @classmethod

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -17,6 +17,7 @@
 import functools
 import threading
 from typing import cast
+from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -43,6 +44,7 @@ class LifecycleNode(Node):
         *,
         name: SomeSubstitutionsType,
         namespace: SomeSubstitutionsType,
+        additional_env: Optional[Dict[SomeSubstitutionsType, SomeSubstitutionsType]] = None,
         **kwargs
     ) -> None:
         """
@@ -71,8 +73,9 @@ class LifecycleNode(Node):
         :param name: The name of the lifecycle node.
           Although it defaults to None it is a required parameter and the default will be removed
           in a future release.
+        :param additional_env: dictionary of environment variables to be added.
         """
-        super().__init__(name=name, namespace=namespace, **kwargs)
+        super().__init__(name=name, namespace=namespace, additional_env=additional_env, **kwargs)
         self.__logger = launch.logging.get_logger(__name__)
         self.__rclpy_subscription = None
         self.__current_state = \

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -127,6 +127,7 @@ class Node(ExecuteProcess):
         remappings: Optional[SomeRemapRules] = None,
         ros_arguments: Optional[Iterable[SomeSubstitutionsType]] = None,
         arguments: Optional[Iterable[SomeSubstitutionsType]] = None,
+        additional_env: Optional[Dict[SomeSubstitutionsType, SomeSubstitutionsType]] = None,
         **kwargs
     ) -> None:
         """
@@ -197,6 +198,7 @@ class Node(ExecuteProcess):
             passed to the node as ROS remapping rules
         :param: ros_arguments list of ROS arguments for the node
         :param: arguments list of extra arguments for the node
+        :param additional_env: dictionary of environment variables to be added.
         """
         if package is not None:
             cmd = [ExecutableInPackage(package=package, executable=executable)]
@@ -217,7 +219,7 @@ class Node(ExecuteProcess):
             normalized_params = normalize_parameters(parameters)
         # Forward 'exec_name' as to ExecuteProcess constructor
         kwargs['name'] = exec_name
-        super().__init__(cmd=cmd, **kwargs)
+        super().__init__(cmd=cmd, additional_env=additional_env, **kwargs)
         self.__package = package
         self.__node_executable = executable
         self.__node_name = name


### PR DESCRIPTION
Signed-off-by: Takahiro Ishikawa <sykwer@gmail.com>

This enhancement enables launch files to pass additional (user-defined) environment variables to the process of a ROS node.
