### PR TITLE
Fix normalize_parameters_dict for multiple nodes in the same namespace

### DIFF
--- a/launch_ros/launch_ros/utilities/to_parameters_list.py
+++ b/launch_ros/launch_ros/utilities/to_parameters_list.py
@@ -48,8 +48,8 @@ def __normalize_parameters_dict(dictionary):
             if isinstance(value, dict):
                 keys.append(key.lstrip('/'))
                 result_dict = normalize_parameters_dict(value, keys, result_dict)
-                # Reset keys in case there are multiple ros__parameter entries
-                keys = []
+                # Clean-up keys for the case of multiple nodes/ros__parameter entries
+                keys.pop()
 
         return result_dict
 

--- a/test_launch_ros/test/test_launch_ros/actions/example_parameters_multiple_nodes.yaml
+++ b/test_launch_ros/test/test_launch_ros/actions/example_parameters_multiple_nodes.yaml
@@ -1,0 +1,9 @@
+/ns_1:
+  /node_1:
+    ros__parameters:
+      param_1: 11
+      param_2: 22
+  node_2:
+    ros__parameters:
+      param_3: 33
+      param_4: 44

--- a/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
@@ -413,7 +413,53 @@ def test_load_node_with_param_file(mock_component_container):
     assert request.parameters[1].name == 'param_3'
     assert request.parameters[1].value.integer_value == 3
 
-    # Case 7: node name not found
+    # Case 7: multiple nodes in one namespace
+    context = _assert_launch_no_errors([
+        LoadComposableNodes(  # Load in same action so it happens sequentially
+            target_container=f'/{TEST_CONTAINER_NAME}',
+            composable_node_descriptions=[
+                ComposableNode(
+                    package='foo_package',
+                    plugin='bar_plugin',
+                    name='node_1',
+                    namespace='ns_1',
+                    parameters=[
+                        parameters_file_dir / 'example_parameters_multiple_nodes.yaml'
+                    ]
+                ),
+                ComposableNode(
+                    package='foo_package',
+                    plugin='bar_plugin',
+                    name='node_2',
+                    namespace='ns_1',
+                    parameters=[
+                        parameters_file_dir / 'example_parameters_multiple_nodes.yaml'
+                    ]
+                )
+            ]
+        )
+    ])
+    request = mock_component_container.requests[-2]
+    assert get_node_name_count(context, '/ns_1/node_1') == 1
+    assert request.node_name == 'node_1'
+    assert request.node_namespace == '/ns_1'
+    assert len(request.parameters) == 2
+    assert request.parameters[0].name == 'param_1'
+    assert request.parameters[0].value.integer_value == 11
+    assert request.parameters[1].name == 'param_2'
+    assert request.parameters[1].value.integer_value == 22
+
+    request = mock_component_container.requests[-1]
+    assert get_node_name_count(context, '/ns_1/node_2') == 1
+    assert request.node_name == 'node_2'
+    assert request.node_namespace == '/ns_1'
+    assert len(request.parameters) == 2
+    assert request.parameters[0].name == 'param_3'
+    assert request.parameters[0].value.integer_value == 33
+    assert request.parameters[1].name == 'param_4'
+    assert request.parameters[1].value.integer_value == 44
+
+    # Case 8: node name not found
     context = _assert_launch_no_errors([
         _load_composable_node(
             package='foo_package',


### PR DESCRIPTION
The fix is initiated by #344, allowing to restore correctly `keys` in `normalize_parameters_dict()` routine after the recursion goes back. This fixes the cases where we have multiple nodes in the same root namespace, like:
```
ns1:
  node1:
    node11:
      ros__params:
        some_param: "AAA"
  node2:
    ros__params:
      another_param: "BBB"
```

According testcase was added to the `test_load_composable_nodes.py`.
The fix was checked manually on the YAML from above, on package `colcon test`, on the example from the initial issue #344, and in multi TurtleBot3 simulation where the problem was actually detected.