### PR TITLE
`WaitForTopics`: exit() methods should not reraise the passed-in exception

### DIFF
--- a/launch_testing_ros/launch_testing_ros/wait_for_topics.py
+++ b/launch_testing_ros/launch_testing_ros/wait_for_topics.py
@@ -93,8 +93,6 @@ class WaitForTopics:
         return self
 
     def __exit__(self, exep_type, exep_value, trace):
-        if exep_type is not None:
-            raise Exception('Exception occured, value: ', exep_value)
         self.shutdown()
 
 


### PR DESCRIPTION
Fixed the bug mentioned in #349.