### PR TITLE
Enable document generation using rosdoc2

### DIFF
--- a/launch_testing_ros/launch_testing_ros/tools/output.py
+++ b/launch_testing_ros/launch_testing_ros/tools/output.py
@@ -41,12 +41,12 @@ def basic_output_filter(
     Create a line filtering function to help output testing.
 
     :param filtered_prefixes: A list of byte strings representing prefixes that will cause
-    output lines to be ignored if they start with one of the prefixes. By default lines
-    starting with the process ID (`b'pid'`) and return code (`b'rc'`) will be ignored.
+        output lines to be ignored if they start with one of the prefixes. By default lines
+        starting with the process ID (`b'pid'`) and return code (`b'rc'`) will be ignored.
     :param filtered_patterns: A list of byte strings representing regexes that will cause
-    output lines to be ignored if they match one of the regexes.
+        output lines to be ignored if they match one of the regexes.
     :param filtered_rmw_implementation: RMW implementation for which the output will be
-    ignored in addition to the `filtered_prefixes`/`filtered_patterns`.
+        ignored in addition to the `filtered_prefixes`/`filtered_patterns`.
     """
     from launch_testing.tools.output import basic_output_filter as base_output_filter
     from launch_testing.tools.output import get_default_filtered_prefixes

--- a/launch_testing_ros/launch_testing_ros/wait_for_topics.py
+++ b/launch_testing_ros/launch_testing_ros/wait_for_topics.py
@@ -27,26 +27,27 @@ class WaitForTopics:
     Wait to receive messages on supplied topics.
 
     Example usage:
-    --------------
 
     from std_msgs.msg import String
 
-    # Method 1, using the 'with' keyword
-    def method_1():
-        topic_list = [('topic_1', String), ('topic_2', String)]
-        with WaitForTopics(topic_list, timeout=5.0):
-            # 'topic_1' and 'topic_2' received at least one message each
-            print('Given topics are receiving messages !')
+    .. code-block:: python
 
-    # Method 2, calling wait() and shutdown() manually
-    def method_2():
-        topic_list = [('topic_1', String), ('topic_2', String)]
-        wait_for_topics = WaitForTopics(topic_list, timeout=5.0)
-        assert wait_for_topics.wait()
-        print('Given topics are receiving messages !')
-        print(wait_for_topics.topics_not_received()) # Should be an empty set
-        print(wait_for_topics.topics_received()) # Should be {'topic_1', 'topic_2'}
-        wait_for_topics.shutdown()
+        # Method 1, using the 'with' keyword
+        def method_1():
+            topic_list = [('topic_1', String), ('topic_2', String)]
+            with WaitForTopics(topic_list, timeout=5.0):
+                # 'topic_1' and 'topic_2' received at least one message each
+                print('Given topics are receiving messages !')
+
+        # Method 2, calling wait() and shutdown() manually
+        def method_2():
+            topic_list = [('topic_1', String), ('topic_2', String)]
+            wait_for_topics = WaitForTopics(topic_list, timeout=5.0)
+            assert wait_for_topics.wait()
+            print('Given topics are receiving messages !')
+            print(wait_for_topics.topics_not_received()) # Should be an empty set
+            print(wait_for_topics.topics_received()) # Should be {'topic_1', 'topic_2'}
+            wait_for_topics.shutdown()
     """
 
     def __init__(self, topic_tuples, timeout=5.0):

--- a/launch_testing_ros/package.xml
+++ b/launch_testing_ros/package.xml
@@ -15,6 +15,7 @@
   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
   <author email="pete.baughman@apex.ai">Pete Baughman</author>
 
+  <exec_depend>ament_index_python</exec_depend>
   <exec_depend>launch_testing</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>rclpy</exec_depend>


### PR DESCRIPTION
Fix missing `exec_depends` in `package.xmls` and docstrings to generate documentation without any warnings using `autodoc`

>Note: Works for all pkgs here except `launch_ros`.
```
  File "/home/yadunund/ws_rolling/src/ros2/launch_ros/launch_ros/launch_ros/parameters_type.py", line 50, in <module>
    SomeSubstitutionsType_types_tuple +
TypeError: unsupported operand type(s) for +: 'SomeSubstitutionsType_types_tuple' and 'tuple'
```
Might be able to fid this if we modify the code to explictly cast `tuple(SomeSubstitutionsType_types_tuple)` as `autodoc` is unable to infer the type given that the dep modules are not imported. 

Incomplete documentation will be generated as a result for `launch_ros`