### PR TITLE
Get rid of unnecessary checks in composable_node_container.

### DIFF
--- a/launch_ros/launch_ros/actions/composable_node_container.py
+++ b/launch_ros/launch_ros/actions/composable_node_container.py
@@ -85,10 +85,7 @@ class ComposableNodeContainer(Node):
                 if node_object.condition() is None or node_object.condition().evaluate(context):
                     valid_composable_nodes.append(node_object)
 
-        if (
-            valid_composable_nodes is not None and
-            len(valid_composable_nodes) > 0
-        ):
+        if valid_composable_nodes:
             from .load_composable_nodes import LoadComposableNodes
             # Perform load action once the container has started.
             load_actions = [


### PR DESCRIPTION
valid_composable_nodes is a local variable that we know is a list.  So we can just do the idiomatic Python thing and check with a simple "if" statement.  This is also faster.