### PR TITLE
cache lookup of importlib metadata in Node action

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -558,10 +558,15 @@ def instantiate_extension(
         extensions[extension_name] = extension_instance
     return extension_instance
 
+g_entry_points_impl = None
+
 
 def get_extensions(logger):
+    global g_entry_points_impl
     group_name = 'launch_ros.node_action'
-    entry_points_impl = importlib_metadata.entry_points()
+    if g_entry_points_impl is None:
+        g_entry_points_impl = importlib_metadata.entry_points()
+    entry_points_impl = g_entry_points_impl
     if hasattr(entry_points_impl, 'select'):
         groups = entry_points_impl.select(group=group_name)
     else:

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -558,6 +558,7 @@ def instantiate_extension(
         extensions[extension_name] = extension_instance
     return extension_instance
 
+
 g_entry_points_impl = None
 
 


### PR DESCRIPTION
The short version of this is that we use `importlib_metadata` to load extensions to the `Node` action via Python's `entry_point` pattern. This lets new packages extend `Node` without changing `launch_ros` itself. The problem is that we load these extensions every time a node needs them and that can take as long as 1 second on some machines. If you have a launch file with hundreds of nodes, like I did, then you get pauses of 30 seconds to a minute before the launch file starts launching things.

---

I used the profiler to find out that this `launch_ros.actions.Node.get_extensions()` was being called some 296 times in my launch file and each time it was taking ~0.4 seconds, leading to a delay of almost 30 seconds:

![Screenshot_2023-06-15_14-58-26](https://github.com/ros2/launch_ros/assets/100427/e77f404d-817a-4b32-a9ec-f6789526cacf)

After the change in this pr, the profiler shows what I experience on the command-line, which is much better behavior, taking almost no time to start launching things, since we only look this up once:

![Screenshot_2023-06-15_15-00-10](https://github.com/ros2/launch_ros/assets/100427/ba14ab0d-cd37-4b0e-8c8e-acf5399872b4)

Some potential issues with this pr:

- it will prevent extensions from changing after launch has started
- we could potentially cache more of the function, but this was the minimal change that made a large difference

For the first item, I don't think the rest of the code is written to assume this is possible in the first place, and I'm not sure what the use case for this would look like. I suppose you could have launch running, and while running install new python packages that add extensions, then cause launch to start a new node after this, and in that case it would not see new extensions. However, I don't know when you'd do that in practice. And I think this change benefits the existing users at the cost of a potential use case that I do not believe folks are using today, but I'm open to hear otherwise.

For the second, I don't think we necessarily need to cache more, based on what I see in the second profiler.