### PR TITLE
Fix an assert in the test_launch_ros tests.

### DIFF
--- a/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_node_frontend.py
@@ -156,7 +156,7 @@ def check_launch_node(file):
     ld = parser.parse_description(root_entity)
     ls = LaunchService()
     ls.include_launch_description(ld)
-    assert(0 == ls.run())
+    assert 0 == ls.run()
     evaluated_parameters = evaluate_parameters(
         ls.context,
         ld.describe_sub_entities()[3]._Node__parameters


### PR DESCRIPTION
Newer flake8 complains about parentheses around asserts, so fix that here.