### PR TITLE
Remove create_future implementation.

### DIFF
--- a/launch_ros/launch_ros/actions/ros_timer.py
+++ b/launch_ros/launch_ros/actions/ros_timer.py
@@ -31,7 +31,6 @@ from launch.launch_context import LaunchContext
 from launch.launch_description_entity import LaunchDescriptionEntity
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.some_substitutions_type import SomeSubstitutionsType_types_tuple
-from launch.utilities import create_future
 from launch.utilities import ensure_argument_type
 from launch.utilities import type_utils
 
@@ -106,5 +105,5 @@ class ROSTimer(TimerAction):
         return 'ROSTimer(period={}, actions=<actions>)'.format(self.__period)
 
     def execute(self, context: LaunchContext):
-        self.__timer_future = create_future(context.asyncio_loop)
+        self.__timer_future = context.asyncio_loop.create_future()
         return super().execute(context)


### PR DESCRIPTION
This is available from Python directly, so just use that.