### PR TITLE
Increase the timeout in wait_for_topic_launch_test.

### DIFF
--- a/launch_testing_ros/test/examples/wait_for_topic_launch_test.py
+++ b/launch_testing_ros/test/examples/wait_for_topic_launch_test.py
@@ -64,7 +64,7 @@ if os.name != 'nt':
 
             # Method 1 : Using the magic methods and 'with' keyword
             with WaitForTopics(
-                topic_list, timeout=2.0, messages_received_buffer_length=10
+                topic_list, timeout=10.0, messages_received_buffer_length=10
             ) as wait_for_node_object_1:
                 assert wait_for_node_object_1.topics_received() == expected_topics
                 assert wait_for_node_object_1.topics_not_received() == set()


### PR DESCRIPTION
In commit 0c081a7791f9b0ab535ce6a60776e1752cdc22c7 (https://github.com/ros2/launch_ros/pull/360) we increased the timeout to 10 seconds to accomodate slower discovery. However, this was partially reverted in
2d125a5105bbfc1d34de17dd70c29905e3ce9732
(https://github.com/ros2/launch_ros/pull/353).

Restore the 10 second timeout to avoid flakes on the buildfarm.