### PR TITLE
Handle spin() ExternalShutdownException.

### DIFF
--- a/launch_testing_ros/launch_testing_ros/wait_for_topics.py
+++ b/launch_testing_ros/launch_testing_ros/wait_for_topics.py
@@ -63,8 +63,14 @@ class WaitForTopics:
         self._prepare_ros_node()
 
         # Start spinning
-        self.__ros_spin_thread = Thread(target=self.__ros_executor.spin)
+        self.__ros_spin_thread = Thread(target=self._spin_handle_external_shutdown)
         self.__ros_spin_thread.start()
+
+    def _spin_handle_external_shutdown(self):
+        try:
+            self.__ros_executor.spin()
+        except rclpy.executors.ExternalShutdownException:
+            pass
 
     def _prepare_ros_node(self):
         node_name = '_test_node_' + ''.join(


### PR DESCRIPTION
When an rclpy executor is spinning, it can shutdown by raising an ExternalShutdownException.  Handle that in wait_for_topics.py so that downstream consumers don't end up throwing an exception themselves.