### PR TITLE
Create py.typed to mark this library as typed

### DIFF
--- a/launch_ros/setup.py
+++ b/launch_ros/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'launch_ros': ['py.typed']},
     install_requires=[
         'setuptools',
         'ament_index_python',


### PR DESCRIPTION
This marker file informs type checkers of downstream libraries that launch_ros is typed.
In my use case, this enables using the `strict` typechecking mode in pyright for a downstream project using launch_ros

This was done for rclpy in https://github.com/ros2/rclpy/pull/946
