### PR TITLE
Fix conflicts in Mergify/bp/humble/pr 353

### DIFF
--- a/launch_testing_ros/launch_testing_ros/wait_for_topics.py
+++ b/launch_testing_ros/launch_testing_ros/wait_for_topics.py
@@ -38,7 +38,10 @@ class WaitForTopics:
         with WaitForTopics(topic_list, timeout=5.0):
             # 'topic_1' and 'topic_2' received at least one message each
             print('Given topics are receiving messages !')
-<<<<<<< HEAD
+            print(wait_for_topics.topics_not_received()) # Should be an empty set
+            print(wait_for_topics.topics_received()) # Should be {'topic_1', 'topic_2'}
+            print(wait_for_topics.messages_received('topic_1')) # Should be [message_1, ...]
+            wait_for_topics.shutdown()
 
     # Method 2, calling wait() and shutdown() manually
     def method_2():
@@ -49,12 +52,6 @@ class WaitForTopics:
         print(wait_for_topics.topics_not_received()) # Should be an empty set
         print(wait_for_topics.topics_received()) # Should be {'topic_1', 'topic_2'}
         wait_for_topics.shutdown()
-=======
-            print(wait_for_topics.topics_not_received()) # Should be an empty set
-            print(wait_for_topics.topics_received()) # Should be {'topic_1', 'topic_2'}
-            print(wait_for_topics.messages_received('topic_1')) # Should be [message_1, ...]
-            wait_for_topics.shutdown()
->>>>>>> 2d125a5 (`WaitForTopics`: get content of messages for each topic (#353))
     """
 
     def __init__(self, topic_tuples, timeout=5.0, messages_received_buffer_length=10):

--- a/launch_testing_ros/test/examples/wait_for_topic_launch_test.py
+++ b/launch_testing_ros/test/examples/wait_for_topic_launch_test.py
@@ -63,13 +63,9 @@ if os.name != 'nt':
             message_pattern = re.compile(r'Hello World: \d+')
 
             # Method 1 : Using the magic methods and 'with' keyword
-<<<<<<< HEAD
-            with WaitForTopics(topic_list, timeout=2.0) as wait_for_node_object_1:
-=======
             with WaitForTopics(
                 topic_list, timeout=2.0, messages_received_buffer_length=10
             ) as wait_for_node_object_1:
->>>>>>> 2d125a5 (`WaitForTopics`: get content of messages for each topic (#353))
                 assert wait_for_node_object_1.topics_received() == expected_topics
                 assert wait_for_node_object_1.topics_not_received() == set()
                 for topic_name, _ in topic_list:


### PR DESCRIPTION
This fixes conflicts for the backport to humble of #353.

Manual colcon test report ✔️ 
```
root@AutonomyML01:/ws# colcon test --packages-select launch_testing_ros --event-handlers=console_cohesion+
Starting >>> launch_testing_ros
--- output: launch_testing_ros                     
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-6.2.5, py-1.10.0, pluggy-0.13.0
cachedir: /ws/build/launch_testing_ros/.pytest_cache
rootdir: /ws/launch_testing_ros, configfile: pytest.ini, testpaths: test
plugins: launch-testing-ros-0.19.6, ament-pep257-0.12.7, ament-copyright-0.12.7, ament-flake8-0.12.7, ament-lint-0.12.7, ament-xmllint-0.12.7, launch-testing-1.0.4, colcon-core-0.12.1
collecting ... 
collected 8 items                                                              

test/test_copyright.py .                                                 [ 12%]
test/test_flake8.py .                                                    [ 25%]
test/test_pep257.py .                                                    [ 37%]
test/examples/check_msgs_launch_test.py .                                [ 50%]
test/examples/check_node_launch_test.py .                                [ 62%]
test/examples/set_param_launch_test.py .                                 [ 75%]
test/examples/talker_listener_launch_test.py .                           [ 87%]
test/examples/wait_for_topic_launch_test.py .                            [100%]

=============================== warnings summary ===============================
test/test_flake8.py::test_flake8
test/test_flake8.py::test_flake8
  Warning: SelectableGroups dict interface is deprecated. Use select.

-- Docs: https://docs.pytest.org/en/stable/warnings.html
--------- generated xml file: /ws/build/launch_testing_ros/pytest.xml ----------
======================== 8 passed, 2 warnings in 18.83s ========================
---
--- stderr: launch_testing_ros

=============================== warnings summary ===============================
test/test_flake8.py::test_flake8
test/test_flake8.py::test_flake8
  Warning: SelectableGroups dict interface is deprecated. Use select.

-- Docs: https://docs.pytest.org/en/stable/warnings.html
---
Finished <<< launch_testing_ros [19.4s]

Summary: 1 package finished [19.5s]
  1 package had stderr output: launch_testing_ros
  ```