### PR TITLE
Cleanup some type annotations.

### DIFF
--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -85,7 +85,7 @@ class LoadComposableNodes(Action):
         super().__init__(**kwargs)
         self.__composable_node_descriptions = composable_node_descriptions
         self.__target_container = target_container
-        self.__final_target_container_name = None  # type: Optional[Text]
+        self.__final_target_container_name: Optional[Text] = None
         self.__logger = launch.logging.get_logger(__name__)
 
     @classmethod

--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -157,7 +157,7 @@ def evaluate_parameters(context: LaunchContext, parameters: Parameters) -> Evalu
     :param parameters: normalized parameters
     :returns: values after evaluating lists of substitutions
     """
-    output_params = []  # type: List[Union[pathlib.Path, Dict[str, EvaluatedParameterValue]]]
+    output_params: List[Union[pathlib.Path, Dict[str, EvaluatedParameterValue]]] = []
     for param in parameters:
         if isinstance(param, ParameterFile):
             # Evaluate a list of Substitution to a file path


### PR DESCRIPTION
Certain versions of mypy complain that these annotations are not being used, since the annotations are only in comments.  But we use the "inline" types everywhere else, so switch this over to the same thing, which should remove the warning.