### PR TITLE
Replace deprecated spin_until_future_complete

### DIFF
--- a/launch_testing_ros/test/examples/set_param_launch_test.py
+++ b/launch_testing_ros/test/examples/set_param_launch_test.py
@@ -65,7 +65,7 @@ class TestFixture(unittest.TestCase):
             request = SetParameters.Request()
             request.parameters = parameters
             future = client.call_async(request)
-            rclpy.spin_until_future_complete(self.node, future, timeout_sec=15.0)
+            rclpy.spin_until_complete(self.node, future, timeout_sec=15.0)
 
             assert future.done(), 'Client request timed out'
 


### PR DESCRIPTION
Replaces #306

Requires https://github.com/ros2/rclpy/pull/1268

Part of https://github.com/ros2/rclcpp/pull/2475