### PR TITLE
Add mechanism to disable workaround for dependency groups

### DIFF
--- a/ros2launch/package.xml
+++ b/ros2launch/package.xml
@@ -25,9 +25,9 @@
   <depend>ros2cli</depend>
   <depend>ros2pkg</depend>
 
-  <!-- explicitly depend on the main launch frontends -->
-  <exec_depend>launch_xml</exec_depend>
-  <exec_depend>launch_yaml</exec_depend>
+  <!-- Explicit group resolution - see ros-infrastructure/catkin_pkg#369 -->
+  <exec_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">launch_xml</exec_depend>
+  <exec_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">launch_yaml</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
See ros-infrastructure/catkin_pkg#369

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=20943)](http://ci.ros2.org/job/ci_linux/20943/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=15234)](http://ci.ros2.org/job/ci_linux-aarch64/15234/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=21617)](http://ci.ros2.org/job/ci_windows/21617/)