### PR TITLE
added notes on prefix

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -196,6 +196,7 @@ class Node(ExecuteProcess):
         :param: remappings ordered list of 'to' and 'from' string pairs to be
             passed to the node as ROS remapping rules
         :param: ros_arguments list of ROS arguments for the node
+        :param: prefix command placed in front of executable on launch
         :param: arguments list of extra arguments for the node
         """
         if package is not None:


### PR DESCRIPTION
`prefix` is part of kwargs, so it can be lost in the documentation

#398 