### PR TITLE
Switch to use rclpy.init context manager.

### DIFF
--- a/launch_testing_ros/test/examples/listener.py
+++ b/launch_testing_ros/test/examples/listener.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from std_msgs.msg import String
@@ -31,16 +32,12 @@ class Listener(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-
-    node = Listener()
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
+        with rclpy.init(args=args):
+            node = Listener()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
 
 
 if __name__ == '__main__':

--- a/launch_testing_ros/test/examples/parameter_blackboard.py
+++ b/launch_testing_ros/test/examples/parameter_blackboard.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 
@@ -24,17 +25,12 @@ class TestNode(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-
-    node = TestNode()
-
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
+        with rclpy.init(args=args):
+            node = TestNode()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
 
 
 if __name__ == '__main__':

--- a/launch_testing_ros/test/examples/talker.py
+++ b/launch_testing_ros/test/examples/talker.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from std_msgs.msg import String
@@ -35,17 +36,12 @@ class Talker(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-
-    node = Talker()
-
     try:
-        rclpy.spin(node)
-    except KeyboardInterrupt:
+        with rclpy.init(args=args):
+            node = Talker()
+            rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
 
 
 if __name__ == '__main__':

--- a/test_launch_ros/test/test_launch_ros/actions/test_ros_timer.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_ros_timer.py
@@ -151,10 +151,9 @@ def test_shutdown_preempts_timers():
 
 @pytest.fixture
 def rclpy_node():
-    rclpy.init()
-    node = rclpy.create_node('test_ros_timer_action_node')
-    yield node
-    rclpy.shutdown()
+    with rclpy.init():
+        node = rclpy.create_node('test_ros_timer_action_node')
+        yield node
 
 
 def test_timer_uses_sim_time(rclpy_node):


### PR DESCRIPTION
This allows us to use less code, but still cleanup at a known time.

This is part of https://github.com/ros2/rclpy/issues/1280