### PR TITLE
Revamp the test_load_composable_nodes test.

### DIFF
--- a/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
@@ -44,30 +44,17 @@ TEST_NODE_NAME = 'test_load_composable_nodes_node'
 
 class MockComponentContainer(rclpy.node.Node):
 
-    def __init__(self):
+    def __init__(self, context):
         # List of LoadNode requests received
         self.requests = []
 
-        self._context = rclpy.context.Context()
-        rclpy.init(context=self._context)
-
-        super().__init__(TEST_CONTAINER_NAME, context=self._context)
+        super().__init__(TEST_CONTAINER_NAME, context=context)
 
         self.load_node_service = self.create_service(
             LoadNode,
             '~/_container/load_node',
             self.load_node_callback
         )
-
-        self._executor = rclpy.executors.SingleThreadedExecutor(context=self._context)
-
-        # Start spinning in a thread
-        self._thread = threading.Thread(
-            target=rclpy.spin,
-            args=(self, self._executor),
-            daemon=True
-        )
-        self._thread.start()
 
     def load_node_callback(self, request, response):
         self.requests.append(request)
@@ -78,12 +65,6 @@ class MockComponentContainer(rclpy.node.Node):
             response.full_node_name = f'{request.node_namespace}/{request.node_name}'
         response.unique_id = len(self.requests)
         return response
-
-    def shutdown(self):
-        self._executor.shutdown()
-        rclpy.shutdown(context=self._context)
-        self.destroy_node()
-        self._thread.join()
 
 
 def _assert_launch_no_errors(actions):
@@ -122,9 +103,20 @@ def _load_composable_node(
 
 @pytest.fixture
 def mock_component_container():
-    container = MockComponentContainer()
-    yield container
-    container.shutdown()
+    context = rclpy.context.Context()
+    with rclpy.init(context=context):
+        executor = rclpy.executors.SingleThreadedExecutor(context=context)
+
+        container = MockComponentContainer(context)
+        executor.add_node(container)
+
+        # Start spinning in a thread
+        thread = threading.Thread(target=lambda exec: exec.spin(), args=(executor,))
+        thread.start()
+        yield container
+        executor.remove_node(container)
+        executor.shutdown()
+        thread.join()
 
 
 def test_load_node(mock_component_container):

--- a/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
@@ -111,7 +111,7 @@ def mock_component_container():
         executor.add_node(container)
 
         # Start spinning in a thread
-        thread = threading.Thread(target=lambda exec: exec.spin(), args=(executor,))
+        thread = threading.Thread(target=lambda executor: executor.spin(), args=(executor,))
         thread.start()
         yield container
         executor.remove_node(container)


### PR DESCRIPTION
In particular, it made little sense to do an rclpy.init in a class that inherited from rclpy.node.Node.  Instead, flip this around and make the mock_component_container responsible for creating the context, doing rclpy.init, creating the node, spinning the executor, and tearing it all down.  Note that this uses the new rclpy.init
context manager as well, which reduces the amount of code we need here.

This is related to https://github.com/ros2/rclpy/issues/1280, though it is its own cleanup as well.