### PR TITLE
Add in a timeout for test_launch_ros.

### DIFF
--- a/test_launch_ros/pytest.ini
+++ b/test_launch_ros/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 junit_family=xunit2
+timeout=900
+timeout_method=thread


### PR DESCRIPTION
That way if there is a bug in it, it won't hang forever.