### PR TITLE
Append ros namespace to target container if available.

### DIFF
--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -220,6 +220,13 @@ class LoadComposableNodes(Action):
                 'target container is neither a ComposableNodeContainer nor a SubstitutionType')
             return
 
+        # Check if a global ros_namespace has been set with push ros namespace.
+        base_ns = context.launch_configurations.get('ros_namespace', None)
+        if base_ns is not None:
+            self.__final_target_container_name = make_namespace_absolute(
+                prefix_namespace(base_ns, self.__final_target_container_name)
+            )
+
         # Create a client to load nodes in the target container.
         self.__rclpy_load_node_client = get_ros_node(context).create_client(
             composition_interfaces.srv.LoadNode, '{}/_container/load_node'.format(


### PR DESCRIPTION
This PR introduces a change to fix #428.

With this change, when a composable node is loaded into a target container that is running under a `ros_namespace` set using `<push_ros_namespace>`, the target container name gets prefixed with `ros_namespace` using the `LaunchContext`. This enables the composable nodes to load into a namespaced target container.

How did I test this:

- `apt install ros-rolling-image-tools`
- Create a python launch file
```
from launch import LaunchDescription
from launch_ros.actions import LoadComposableNodes, Node, PushROSNamespace
from launch_ros.descriptions import ComposableNode

def generate_launch_description():

    set_ns = PushROSNamespace("test_ns")
    container = Node(
        name='image_container',
        package='rclcpp_components',
        executable='component_container',
        output='both',
    )

    load_composable_nodes = LoadComposableNodes(
        target_container='image_container',
        composable_node_descriptions=[
            ComposableNode(
                package='image_tools',
                plugin='image_tools::Cam2Image',
                name='cam2image',
                remappings=[('/image', '/burgerimage')],
                parameters=[{'width': 320, 'height': 240, 'burger_mode': True, 'history': 'keep_last'}],
                extra_arguments=[{'use_intra_process_comms': True}],
            ),
            ComposableNode(
                package='image_tools',
                plugin='image_tools::ShowImage',
                name='showimage',
                remappings=[('/image', '/burgerimage')],
                parameters=[{'history': 'keep_last'}],
                extra_arguments=[{'use_intra_process_comms': True}]
            ),
        ],
    )

    return LaunchDescription([set_ns, container, load_composable_nodes])

```

- Confirm that the composable nodes are loaded into the namespaced target container:
```
[INFO] [launch_ros.actions.load_composable_nodes]: Loaded node '/test_ns/cam2image' in container '/test_ns/image_container'
[component_container-1] [INFO] [1734128809.737064712] [test_ns.image_container]: Found class: rclcpp_components::NodeFactoryTemplate<image_tools::Cam2Image>
[component_container-1] [INFO] [1734128809.737089661] [test_ns.image_container]: Found class: rclcpp_components::NodeFactoryTemplate<image_tools::ShowImage>
[component_container-1] [INFO] [1734128809.737094571] [test_ns.image_container]: Instantiate class: rclcpp_components::NodeFactoryTemplate<image_tools::ShowImage>
[component_container-1] [INFO] [1734128809.742501542] [test_ns.showimage]: Subscribing to topic 'image'
[INFO] [launch_ros.actions.load_composable_nodes]: Loaded node '/test_ns/showimage' in container '/test_ns/image_container'
[component_container-1] [INFO] [1734128809.768871705] [test_ns.cam2image]: Publishing image #1
[component_container-1] [INFO] [1734128809.769063393] [test_ns.showimage]: Received image #camera_frame
```
- Create an xml launch file
```
<launch>
    <group>
        <push_ros_namespace namespace="test_ns"/>

        <node_container pkg="rclcpp_components" exec="component_container" name="container" namespace=""/>
            <load_composable_node target="container">
                <composable_node name="cam2image" pkg="image_tools" plugin="image_tools::Cam2Image">
                    <remap from="image" to="burger_image" />
                    <param name="width" value="320" />
                    <param name="height" value="240" />
                    <param name="burger_mode" value="True" />
                    <param name="history" value="keep_last" />
                </composable_node>
                <composable_node name="showimage" pkg="image_tools" plugin="image_tools::ShowImage">
                    <remap from="image" to="burger_image" />
                    <param name="history" value="keep_last" />
                </composable_node>
            </load_composable_node>
    </group>
</launch>
```
- Confirm that the composable nodes are loaded into the namespaced target container:
```
[INFO] [launch_ros.actions.load_composable_nodes]: Loaded node '/test_ns/cam2image' in container '/test_ns/container'
[component_container-1] [INFO] [1734130914.070237617] [test_ns.container]: Found class: rclcpp_components::NodeFactoryTemplate<image_tools::Cam2Image>
[component_container-1] [INFO] [1734130914.070265706] [test_ns.container]: Found class: rclcpp_components::NodeFactoryTemplate<image_tools::ShowImage>
[component_container-1] [INFO] [1734130914.070270385] [test_ns.container]: Instantiate class: rclcpp_components::NodeFactoryTemplate<image_tools::ShowImage>
[component_container-1] [INFO] [1734130914.073884311] [test_ns.showimage]: Subscribing to topic 'image'
[INFO] [launch_ros.actions.load_composable_nodes]: Loaded node '/test_ns/showimage' in container '/test_ns/container'
[component_container-1] [INFO] [1734130914.101434113] [test_ns.cam2image]: Publishing image #1
[component_container-1] [INFO] [1734130914.102238122] [test_ns.showimage]: Received image #camera_frame
```
- `ros2 node list`
```
/launch_ros_780940
/test_ns/cam2image
/test_ns/container
/test_ns/showimage
```

## *Without* the changes in this PR, the output from the launch would be:
```
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [component_container-1]: process started with pid [779037]
```
And the composable nodes wouldn't show up with `ros2 node list`
```
/launch_ros_779454
/test_ns/container
```