### PR TITLE
Autostarting lifecycle nodes and example launch file demo

### DIFF
--- a/launch_ros/examples/lifecycle_autostart_pub_sub_launch.py
+++ b/launch_ros/examples/lifecycle_autostart_pub_sub_launch.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Open Source Robotics Foundation, Inc.
+# Copyright 2024 Open Navigation LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/launch_ros/examples/lifecycle_autostart_pub_sub_launch.py
+++ b/launch_ros/examples/lifecycle_autostart_pub_sub_launch.py
@@ -27,8 +27,6 @@ import launch_ros.actions  # noqa: E402
 import launch_ros.events  # noqa: E402
 import launch_ros.events.lifecycle  # noqa: E402
 
-import lifecycle_msgs.msg  # noqa: E402
-
 
 def main(argv=sys.argv[1:]):
     ld = launch.LaunchDescription()

--- a/launch_ros/examples/lifecycle_autostart_pub_sub_launch.py
+++ b/launch_ros/examples/lifecycle_autostart_pub_sub_launch.py
@@ -1,0 +1,57 @@
+# Copyright 2018 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Launch a lifecycle talker and a lifecycle listener."""
+
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'launch'))  # noqa
+
+import launch  # noqa: E402
+import launch.actions  # noqa: E402
+import launch.events  # noqa: E402
+
+import launch_ros.actions  # noqa: E402
+import launch_ros.events  # noqa: E402
+import launch_ros.events.lifecycle  # noqa: E402
+
+import lifecycle_msgs.msg  # noqa: E402
+
+
+def main(argv=sys.argv[1:]):
+    ld = launch.LaunchDescription()
+    talker_node = launch_ros.actions.LifecycleNode(
+        name='talker',
+        namespace='',
+        package='lifecycle',
+        executable='lifecycle_talker',
+        output='screen',
+        autostart=True)
+    listener_node = launch_ros.actions.LifecycleNode(
+        name='listener',
+        namespace='',
+        package='lifecycle',
+        executable='lifecycle_listener',
+        output='screen',
+        autostart=True)
+    ld.add_action(talker_node)
+    ld.add_action(listener_node)
+    ls = launch.LaunchService(argv=argv)
+    ls.include_launch_description(ld)
+    return ls.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/launch_ros/examples/lifecycle_component_autostart_pub_sub_launch.py
+++ b/launch_ros/examples/lifecycle_component_autostart_pub_sub_launch.py
@@ -1,0 +1,66 @@
+# Copyright 2024 Open Navigation LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Launch a lifecycle talker and a lifecycle listener."""
+
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'launch'))  # noqa
+
+import launch  # noqa: E402
+
+from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes
+from launch_ros.descriptions import ComposableNode
+
+
+def main(argv=sys.argv[1:]):
+    ld = launch.LaunchDescription()
+
+    # Can autostart from the container
+    container = ComposableNodeContainer(
+            name='lifecycle_component_container',
+            namespace='',
+            package='rclcpp_components',
+            executable='component_container',
+            composable_node_descriptions=[
+                ComposableNode(
+                    package='composition',
+                    plugin='composition::Listener',
+                    name='listener',
+                    autostart=True),
+                ]
+            )
+
+    # ... and also from an external loader
+    loader = LoadComposableNodes(
+        target_container='lifecycle_component_container',
+        composable_node_descriptions=[
+            ComposableNode(
+                package='composition',
+                plugin='composition::Talker',
+                name='talker',
+                autostart=True),
+        ],
+    )
+
+    ld.add_action(container)
+    ld.add_action(loader)
+    ls = launch.LaunchService(argv=argv)
+    ls.include_launch_description(ld)
+    return ls.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/launch_ros/examples/lifecycle_component_autostart_pub_sub_launch.py
+++ b/launch_ros/examples/lifecycle_component_autostart_pub_sub_launch.py
@@ -14,15 +14,12 @@
 
 """Launch a lifecycle talker and a lifecycle listener."""
 
-import os
 import sys
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))  # noqa
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'launch'))  # noqa
+
+import launch  # noqa: E402
 
 from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
-
-import launch  # noqa: E402
 
 
 def main(argv=sys.argv[1:]):

--- a/launch_ros/examples/lifecycle_component_autostart_pub_sub_launch.py
+++ b/launch_ros/examples/lifecycle_component_autostart_pub_sub_launch.py
@@ -19,10 +19,10 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))  # noqa
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'launch'))  # noqa
 
-import launch  # noqa: E402
-
 from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
+
+import launch  # noqa: E402
 
 
 def main(argv=sys.argv[1:]):

--- a/launch_ros/examples/lifecycle_component_autostart_pub_sub_launch.py
+++ b/launch_ros/examples/lifecycle_component_autostart_pub_sub_launch.py
@@ -19,7 +19,7 @@ import sys
 import launch  # noqa: E402
 
 from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes
-from launch_ros.descriptions import ComposableNode
+from launch_ros.descriptions import ComposableLifecycleNode
 
 
 def main(argv=sys.argv[1:]):
@@ -32,7 +32,7 @@ def main(argv=sys.argv[1:]):
             package='rclcpp_components',
             executable='component_container',
             composable_node_descriptions=[
-                ComposableNode(
+                ComposableLifecycleNode(
                     package='composition',
                     plugin='composition::Listener',
                     name='listener',
@@ -44,7 +44,7 @@ def main(argv=sys.argv[1:]):
     loader = LoadComposableNodes(
         target_container='lifecycle_component_container',
         composable_node_descriptions=[
-            ComposableNode(
+            ComposableLifecycleNode(
                 package='composition',
                 plugin='composition::Talker',
                 name='talker',

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -14,9 +14,6 @@
 
 """Module for the LifecycleNode action."""
 
-import functools
-import threading
-from typing import cast
 from typing import List
 from typing import Optional
 
@@ -30,10 +27,7 @@ import lifecycle_msgs.srv
 
 from .lifecycle_transition import LifecycleTransition
 from .node import Node
-from ..events.lifecycle import ChangeState
-from ..events.lifecycle import StateTransition
 
-from ..ros_adapters import get_ros_node
 from ..utilities import LifecycleEventManager
 
 

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -86,7 +86,7 @@ class LifecycleNode(Node):
         if '<node_name_unspecified>' in self.node_name:
             raise RuntimeError('node_name unexpectedly incomplete for lifecycle node')
 
-        self.__lifecycle_event_manager = LifecycleEventManager(self.node_name)
+        self.__lifecycle_event_manager = LifecycleEventManager(self)
         self.__lifecycle_event_manager.setup_lifecycle_manager(context)
 
         # If autostart is enabled, transition to the 'active' state.

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -76,6 +76,7 @@ class LifecycleNode(Node):
         super().__init__(name=name, namespace=namespace, **kwargs)
         self.__logger = launch.logging.get_logger(__name__)
         self.__rclpy_subscription = None
+        self.__rclpy_change_state_client = None
 
     @property
     def is_lifecycle_node(self):

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -76,8 +76,6 @@ class LifecycleNode(Node):
         super().__init__(name=name, namespace=namespace, **kwargs)
         self.__logger = launch.logging.get_logger(__name__)
         self.__rclpy_subscription = None
-        self.__current_state = \
-            ChangeState.valid_states[lifecycle_msgs.msg.State.PRIMARY_STATE_UNKNOWN]
 
     @property
     def is_lifecycle_node(self):
@@ -86,7 +84,6 @@ class LifecycleNode(Node):
     def _on_transition_event(self, context, msg):
         try:
             event = StateTransition(action=self, msg=msg)
-            self.__current_state = ChangeState.valid_states[msg.goal_state.id]
             context.asyncio_loop.call_soon_threadsafe(lambda: context.emit_event_sync(event))
         except Exception as exc:
             self.__logger.error(

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -34,6 +34,7 @@ from ..events.lifecycle import ChangeState
 from ..events.lifecycle import StateTransition
 
 from ..ros_adapters import get_ros_node
+from ..utilities import LifecycleEventManager
 
 
 class LifecycleNode(Node):
@@ -75,69 +76,11 @@ class LifecycleNode(Node):
         """
         super().__init__(name=name, namespace=namespace, **kwargs)
         self.__logger = launch.logging.get_logger(__name__)
-        self.__rclpy_subscription = None
-        self.__rclpy_change_state_client = None
+        self.__lifecycle_event_manager = None
 
     @property
     def is_lifecycle_node(self):
         return True
-
-    def _on_transition_event(self, context, msg):
-        try:
-            event = StateTransition(action=self, msg=msg)
-            context.asyncio_loop.call_soon_threadsafe(lambda: context.emit_event_sync(event))
-        except Exception as exc:
-            self.__logger.error(
-                "Exception in handling of 'lifecycle.msg.TransitionEvent': {}".format(exc))
-
-    def _call_change_state(self, request, context: launch.LaunchContext):
-        while not self.__rclpy_change_state_client.wait_for_service(timeout_sec=1.0):
-            if context.is_shutdown:
-                self.__logger.warning(
-                    "Abandoning wait for the '{}' service, due to shutdown.".format(
-                        self.__rclpy_change_state_client.srv_name),
-                )
-                return
-
-        # Asynchronously wait so that we can periodically check for shutdown.
-        event = threading.Event()
-
-        def unblock(future):
-            nonlocal event
-            event.set()
-
-        response_future = self.__rclpy_change_state_client.call_async(request)
-        response_future.add_done_callback(unblock)
-
-        while not event.wait(1.0):
-            if context.is_shutdown:
-                self.__logger.warning(
-                    "Abandoning wait for the '{}' service response, due to shutdown.".format(
-                        self.__rclpy_change_state_client.srv_name),
-                )
-                response_future.cancel()
-                return
-
-        if response_future.exception() is not None:
-            raise response_future.exception()
-        response = response_future.result()
-
-        if not response.success:
-            self.__logger.error(
-                "Failed to make transition '{}' for LifecycleNode '{}'".format(
-                    ChangeState.valid_transitions[request.transition.id],
-                    self.node_name,
-                )
-            )
-
-    def _on_change_state_event(self, context: launch.LaunchContext) -> None:
-        typed_event = cast(ChangeState, context.locals.event)
-        if not typed_event.lifecycle_node_matcher(self):
-            return None
-        request = lifecycle_msgs.srv.ChangeState.Request()
-        request.transition.id = typed_event.transition_id
-        context.add_completion_future(
-            context.asyncio_loop.run_in_executor(None, self._call_change_state, request, context))
 
     def execute(self, context: launch.LaunchContext) -> Optional[List[Action]]:
         """
@@ -148,22 +91,9 @@ class LifecycleNode(Node):
         self._perform_substitutions(context)  # ensure self.node_name is expanded
         if '<node_name_unspecified>' in self.node_name:
             raise RuntimeError('node_name unexpectedly incomplete for lifecycle node')
-        node = get_ros_node(context)
-        # Create a subscription to monitor the state changes of the subprocess.
-        self.__rclpy_subscription = node.create_subscription(
-            lifecycle_msgs.msg.TransitionEvent,
-            '{}/transition_event'.format(self.node_name),
-            functools.partial(self._on_transition_event, context),
-            10)
-        # Create a service client to change state on demand.
-        self.__rclpy_change_state_client = node.create_client(
-            lifecycle_msgs.srv.ChangeState,
-            '{}/change_state'.format(self.node_name))
-        # Register an event handler to change states on a ChangeState lifecycle event.
-        context.register_event_handler(launch.EventHandler(
-            matcher=lambda event: isinstance(event, ChangeState),
-            entities=[launch.actions.OpaqueFunction(function=self._on_change_state_event)],
-        ))
+
+        self.__lifecycle_event_manager = LifecycleEventManager(self.node_name)
+        self.__lifecycle_event_manager.setup_lifecycle_manager(context)
 
         # If autostart is enabled, transition to the 'active' state.
         autostart_actions = None

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -28,10 +28,10 @@ import launch.logging
 import lifecycle_msgs.msg
 import lifecycle_msgs.srv
 
+from .lifecycle_transition import LifecycleTransition
 from .node import Node
 from ..events.lifecycle import ChangeState
 from ..events.lifecycle import StateTransition
-from .lifecycle_transition import LifecycleTransition
 
 from ..ros_adapters import get_ros_node
 

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -39,6 +39,7 @@ class LifecycleNode(Node):
         *,
         name: SomeSubstitutionsType,
         namespace: SomeSubstitutionsType,
+        autostart: Optional[bool] = False,
         **kwargs
     ) -> None:
         """
@@ -70,7 +71,13 @@ class LifecycleNode(Node):
         """
         super().__init__(name=name, namespace=namespace, **kwargs)
         self.__logger = launch.logging.get_logger(__name__)
+        self.__autostart = autostart
         self.__lifecycle_event_manager = None
+
+    @property
+    def node_autostart(self):
+        """Getter for autostart."""
+        return self.__autostart
 
     @property
     def is_lifecycle_node(self):

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -68,6 +68,8 @@ class LifecycleNode(Node):
         :param name: The name of the lifecycle node.
           Although it defaults to None it is a required parameter and the default will be removed
           in a future release.
+        :param namespace: The ROS namespace for this Node
+        :param autostart: Whether or not to automatically transition to the 'active' state.
         """
         super().__init__(name=name, namespace=namespace, **kwargs)
         self.__logger = launch.logging.get_logger(__name__)

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -39,7 +39,7 @@ class LifecycleNode(Node):
         *,
         name: SomeSubstitutionsType,
         namespace: SomeSubstitutionsType,
-        autostart: Optional[bool] = False,
+        autostart: bool = False,
         **kwargs
     ) -> None:
         """

--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -85,6 +85,9 @@ class LifecycleNode(Node):
     def is_lifecycle_node(self):
         return True
 
+    def get_lifecycle_event_manager(self):
+        return self.__lifecycle_event_manager
+
     def execute(self, context: launch.LaunchContext) -> Optional[List[Action]]:
         """
         Execute the action.

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -38,7 +38,10 @@ from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
 from launch_ros.parameter_descriptions import ParameterFile
 
+import lifecycle_msgs.msg
+
 from .composable_node_container import ComposableNodeContainer
+from .lifecycle_transition import LifecycleTransition
 
 from ..descriptions import ComposableNode
 from ..ros_adapters import get_ros_node
@@ -230,11 +233,32 @@ class LoadComposableNodes(Action):
         # Generate load requests before execute() exits to avoid race with context changing
         # due to scope change (e.g. if loading nodes from within a GroupAction).
         load_node_requests = []
+        autostart_actions = []
         for node_description in self.__composable_node_descriptions:
             request = get_composable_node_load_request(node_description, context)
             # The request can be None if the node description's condition evaluates to False
             if request is not None:
                 load_node_requests.append(request)
+
+            # If autostart is enabled, transition to the 'active' state.
+            if node_description.node_autostart:
+                complete_node_name = request.node_namespace + request.node_name
+                if not complete_node_name.startswith('/'):
+                    complete_node_name = '/' + complete_node_name
+                self.__logger.info(
+                    'Autostart enabled for requested lifecycle node {}'.format(complete_node_name))
+                node_description.init_lifecycle_event_manager(complete_node_name, context)
+                autostart_actions.append(
+                    LifecycleTransition(
+                        lifecycle_node_names=[complete_node_name],
+                        transition_ids=[lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE]
+                    ))
+                autostart_actions.append(
+                    LifecycleTransition(
+                        lifecycle_node_names=[complete_node_name],
+                        transition_ids=[lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE]
+                    ),
+                )
 
         if load_node_requests:
             context.add_completion_future(
@@ -242,6 +266,14 @@ class LoadComposableNodes(Action):
                     None, self._load_in_sequence, load_node_requests, context
                 )
             )
+
+        load_actions = super().execute(context)
+        if load_actions is not None and len(autostart_actions) != 0:
+            return load_actions + autostart_actions
+        if load_actions is not None:
+            return load_actions
+        if len(autostart_actions) != 0:
+            return autostart_actions
 
 
 def get_composable_node_load_request(

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -247,7 +247,7 @@ class LoadComposableNodes(Action):
                     complete_node_name = '/' + complete_node_name
                 self.__logger.info(
                     'Autostart enabled for requested lifecycle node {}'.format(complete_node_name))
-                node_description.init_lifecycle_event_manager(complete_node_name, context)
+                node_description.init_lifecycle_event_manager(node_description, context)
                 autostart_actions.append(
                     LifecycleTransition(
                         lifecycle_node_names=[complete_node_name],

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -247,7 +247,7 @@ class LoadComposableNodes(Action):
                     complete_node_name = '/' + complete_node_name
                 self.__logger.info(
                     'Autostart enabled for requested lifecycle node {}'.format(complete_node_name))
-                node_description.init_lifecycle_event_manager(node_description, context)
+                node_description.init_lifecycle_event_manager(context)
                 autostart_actions.append(
                     LifecycleTransition(
                         lifecycle_node_names=[complete_node_name],

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -241,7 +241,7 @@ class LoadComposableNodes(Action):
                 load_node_requests.append(request)
 
             # If autostart is enabled, transition to the 'active' state.
-            if node_description.node_autostart:
+            if hasattr(node_description, 'node_autostart') and node_description.node_autostart:
                 complete_node_name = request.node_namespace + request.node_name
                 if not complete_node_name.startswith('/'):
                     complete_node_name = '/' + complete_node_name

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -125,6 +125,7 @@ class Node(ExecuteProcess):
         exec_name: Optional[SomeSubstitutionsType] = None,
         parameters: Optional[SomeParameters] = None,
         remappings: Optional[SomeRemapRules] = None,
+        autostart: Optional[bool] = False,
         ros_arguments: Optional[Iterable[SomeSubstitutionsType]] = None,
         arguments: Optional[Iterable[SomeSubstitutionsType]] = None,
         **kwargs
@@ -222,6 +223,7 @@ class Node(ExecuteProcess):
         self.__node_executable = executable
         self.__node_name = name
         self.__node_namespace = namespace
+        self.__autostart = autostart
         self.__parameters = [] if parameters is None else normalized_params
         self.__remappings = [] if remappings is None else list(normalize_remap_rules(remappings))
         self.__ros_arguments = ros_arguments
@@ -361,6 +363,15 @@ class Node(ExecuteProcess):
         if self.__final_node_name is None:
             raise RuntimeError("cannot access 'node_name' before executing action")
         return self.__final_node_name
+
+    @property
+    def node_autostart(self):
+        """Getter for autostart."""
+        return self.__autostart
+
+    @property
+    def is_lifecycle_node(self):
+        return False
 
     def is_node_name_fully_specified(self):
         keywords = (self.UNSPECIFIED_NODE_NAME, self.UNSPECIFIED_NODE_NAMESPACE)

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -125,7 +125,6 @@ class Node(ExecuteProcess):
         exec_name: Optional[SomeSubstitutionsType] = None,
         parameters: Optional[SomeParameters] = None,
         remappings: Optional[SomeRemapRules] = None,
-        autostart: Optional[bool] = False,
         ros_arguments: Optional[Iterable[SomeSubstitutionsType]] = None,
         arguments: Optional[Iterable[SomeSubstitutionsType]] = None,
         **kwargs
@@ -223,7 +222,6 @@ class Node(ExecuteProcess):
         self.__node_executable = executable
         self.__node_name = name
         self.__node_namespace = namespace
-        self.__autostart = autostart
         self.__parameters = [] if parameters is None else normalized_params
         self.__remappings = [] if remappings is None else list(normalize_remap_rules(remappings))
         self.__ros_arguments = ros_arguments
@@ -367,7 +365,7 @@ class Node(ExecuteProcess):
     @property
     def node_autostart(self):
         """Getter for autostart."""
-        return self.__autostart
+        return False
 
     @property
     def is_lifecycle_node(self):

--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -362,15 +362,6 @@ class Node(ExecuteProcess):
             raise RuntimeError("cannot access 'node_name' before executing action")
         return self.__final_node_name
 
-    @property
-    def node_autostart(self):
-        """Getter for autostart."""
-        return False
-
-    @property
-    def is_lifecycle_node(self):
-        return False
-
     def is_node_name_fully_specified(self):
         keywords = (self.UNSPECIFIED_NODE_NAME, self.UNSPECIFIED_NODE_NAMESPACE)
         return all(x not in self.node_name for x in keywords)

--- a/launch_ros/launch_ros/descriptions/__init__.py
+++ b/launch_ros/launch_ros/descriptions/__init__.py
@@ -15,6 +15,7 @@
 """descriptions Module."""
 
 from .composable_node import ComposableNode
+from .composable_lifecycle_node import ComposableLifecycleNode
 from ..parameter_descriptions import Parameter
 from ..parameter_descriptions import ParameterFile
 from ..parameter_descriptions import ParameterValue
@@ -22,6 +23,7 @@ from ..parameter_descriptions import ParameterValue
 
 __all__ = [
     'ComposableNode',
+    'ComposableLifecycleNode',
     'Parameter',
     'ParameterFile',
     'ParameterValue',

--- a/launch_ros/launch_ros/descriptions/__init__.py
+++ b/launch_ros/launch_ros/descriptions/__init__.py
@@ -14,8 +14,8 @@
 
 """descriptions Module."""
 
-from .composable_node import ComposableNode
 from .composable_lifecycle_node import ComposableLifecycleNode
+from .composable_node import ComposableNode
 from ..parameter_descriptions import Parameter
 from ..parameter_descriptions import ParameterFile
 from ..parameter_descriptions import ParameterValue

--- a/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
@@ -19,7 +19,6 @@ from typing import Optional
 
 import launch
 from launch.substitution import Substitution
-# from launch.utilities import ensure_argument_type
 from launch.utilities import perform_substitutions
 from launch_ros.parameters_type import Parameters
 from launch_ros.remap_rule_type import RemapRules

--- a/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
@@ -1,0 +1,121 @@
+# Copyright 2025 Open Navigation LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for a description of a ComposableLifecycleNode."""
+
+from typing import List
+from typing import Optional
+
+import launch
+from launch.condition import Condition
+from launch.some_substitutions_type import SomeSubstitutionsType
+from launch.substitution import Substitution
+# from launch.utilities import ensure_argument_type
+from launch.utilities import perform_substitutions
+from launch_ros.parameters_type import Parameters
+from launch_ros.parameters_type import SomeParameters
+from launch_ros.remap_rule_type import RemapRules
+from launch_ros.remap_rule_type import SomeRemapRules
+from launch_ros.utilities import LifecycleEventManager
+
+from .composable_node import ComposableNode
+
+
+class ComposableLifecycleNode(ComposableNode):
+    """Describes a lifecycle node that can be loaded into a container with other nodes."""
+
+    def __init__(
+        self, *,
+        package: SomeSubstitutionsType,
+        plugin: SomeSubstitutionsType,
+        name: Optional[SomeSubstitutionsType] = None,
+        namespace: Optional[SomeSubstitutionsType] = None,
+        parameters: Optional[SomeParameters] = None,
+        autostart: Optional[bool] = False,
+        remappings: Optional[SomeRemapRules] = None,
+        extra_arguments: Optional[SomeParameters] = None,
+        condition: Optional[Condition] = None,
+    ) -> None:
+        """
+        Initialize a ComposableNode description.
+
+        :param package: name of the ROS package the node plugin lives in
+        :param plugin: name of the plugin to be loaded
+        :param name: name to give to the ROS node
+        :param namespace: namespace to give to the ROS node
+        :param parameters: list of either paths to yaml files or dictionaries of parameters
+        :param autostart: Whether to autostart lifecycle node in the activated state
+        :param remappings: list of from/to pairs for remapping names
+        :param extra_arguments: container specific arguments to be passed to the loaded node
+        :param condition: action will be executed if the condition evaluates to true
+        """
+        super().__init__(
+            package=package,
+            plugin=plugin,
+            name=name,
+            namespace=namespace,
+            parameters=parameters,
+            remappings=remappings,
+            extra_arguments=extra_arguments,
+            condition=condition)
+
+        self.__autostart = autostart
+        self.__lifecycle_event_manager = None
+        self.__node_name = self._ComposableNode__node_name
+
+    def init_lifecycle_event_manager(self, node, context: launch.LaunchContext) -> None:
+        # LifecycleEventManager needs a pre-substitution node name
+        self.__node_name = perform_substitutions(context, node.node_name)
+        self.__lifecycle_event_manager = LifecycleEventManager(node)
+        self.__lifecycle_event_manager.setup_lifecycle_manager(context)
+
+    @property
+    def package(self) -> List[Substitution]:
+        """Get node package name as a sequence of substitutions to be performed."""
+        return self._ComposableNode__package
+
+    @property
+    def node_plugin(self) -> List[Substitution]:
+        """Get node plugin name as a sequence of substitutions to be performed."""
+        return self._ComposableNode__node_plugin
+
+    @property
+    def node_name(self) -> Optional[List[Substitution]]:
+        """Get node name as a sequence of substitutions to be performed."""
+        return self.__node_name
+
+    @property
+    def node_namespace(self) -> Optional[List[Substitution]]:
+        """Get node namespace as a sequence of substitutions to be performed."""
+        return self._ComposableNode__node_namespace
+
+    @property
+    def node_autostart(self):
+        """Getter for autostart."""
+        return self.__autostart
+
+    @property
+    def parameters(self) -> Optional[Parameters]:
+        """Get node parameter YAML files or dicts with substitutions to be performed."""
+        return self._ComposableNode__parameters
+
+    @property
+    def remappings(self) -> Optional[RemapRules]:
+        """Get node remapping rules as (from, to) tuples with substitutions to be performed."""
+        return self._ComposableNode__remappings
+
+    @property
+    def extra_arguments(self) -> Optional[Parameters]:
+        """Get container extra arguments YAML files or dicts with substitutions to be performed."""
+        return self._ComposableNode__extra_arguments

--- a/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
@@ -34,61 +34,37 @@ from .composable_node import ComposableNode
 
 class ComposableLifecycleNode(ComposableNode):
     """Describes a lifecycle node that can be loaded into a container with other nodes."""
-
     def __init__(
         self, *,
-        package: SomeSubstitutionsType,
-        plugin: SomeSubstitutionsType,
-        name: Optional[SomeSubstitutionsType] = None,
-        namespace: Optional[SomeSubstitutionsType] = None,
-        parameters: Optional[SomeParameters] = None,
-        autostart: Optional[bool] = False,
-        remappings: Optional[SomeRemapRules] = None,
-        extra_arguments: Optional[SomeParameters] = None,
-        condition: Optional[Condition] = None,
+        autostart: bool = False,
+        **kwargs
     ) -> None:
         """
-        Initialize a ComposableNode description.
+        Initialize a ComposableLifecycleNode description.
 
-        :param package: name of the ROS package the node plugin lives in
-        :param plugin: name of the plugin to be loaded
-        :param name: name to give to the ROS node
-        :param namespace: namespace to give to the ROS node
-        :param parameters: list of either paths to yaml files or dictionaries of parameters
         :param autostart: Whether to autostart lifecycle node in the activated state
-        :param remappings: list of from/to pairs for remapping names
-        :param extra_arguments: container specific arguments to be passed to the loaded node
-        :param condition: action will be executed if the condition evaluates to true
         """
-        super().__init__(
-            package=package,
-            plugin=plugin,
-            name=name,
-            namespace=namespace,
-            parameters=parameters,
-            remappings=remappings,
-            extra_arguments=extra_arguments,
-            condition=condition)
+        super().__init__(**kwargs)
 
         self.__autostart = autostart
         self.__lifecycle_event_manager = None
-        self.__node_name = self._ComposableNode__node_name
+        self.__node_name = super().node_name
 
-    def init_lifecycle_event_manager(self, node, context: launch.LaunchContext) -> None:
+    def init_lifecycle_event_manager(self, context: launch.LaunchContext) -> None:
         # LifecycleEventManager needs a pre-substitution node name
-        self.__node_name = perform_substitutions(context, node.node_name)
-        self.__lifecycle_event_manager = LifecycleEventManager(node)
+        self.__node_name = perform_substitutions(context, self.node_name)
+        self.__lifecycle_event_manager = LifecycleEventManager(self)
         self.__lifecycle_event_manager.setup_lifecycle_manager(context)
 
     @property
     def package(self) -> List[Substitution]:
         """Get node package name as a sequence of substitutions to be performed."""
-        return self._ComposableNode__package
+        return super().package
 
     @property
     def node_plugin(self) -> List[Substitution]:
         """Get node plugin name as a sequence of substitutions to be performed."""
-        return self._ComposableNode__node_plugin
+        return super().node_plugin
 
     @property
     def node_name(self) -> Optional[List[Substitution]]:
@@ -98,7 +74,7 @@ class ComposableLifecycleNode(ComposableNode):
     @property
     def node_namespace(self) -> Optional[List[Substitution]]:
         """Get node namespace as a sequence of substitutions to be performed."""
-        return self._ComposableNode__node_namespace
+        return super().node_namespace
 
     @property
     def node_autostart(self):
@@ -108,14 +84,14 @@ class ComposableLifecycleNode(ComposableNode):
     @property
     def parameters(self) -> Optional[Parameters]:
         """Get node parameter YAML files or dicts with substitutions to be performed."""
-        return self._ComposableNode__parameters
+        return super().parameters
 
     @property
     def remappings(self) -> Optional[RemapRules]:
         """Get node remapping rules as (from, to) tuples with substitutions to be performed."""
-        return self._ComposableNode__remappings
+        return super().remappings
 
     @property
     def extra_arguments(self) -> Optional[Parameters]:
         """Get container extra arguments YAML files or dicts with substitutions to be performed."""
-        return self._ComposableNode__extra_arguments
+        return super().extra_arguments

--- a/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
@@ -18,15 +18,11 @@ from typing import List
 from typing import Optional
 
 import launch
-from launch.condition import Condition
-from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.substitution import Substitution
 # from launch.utilities import ensure_argument_type
 from launch.utilities import perform_substitutions
 from launch_ros.parameters_type import Parameters
-from launch_ros.parameters_type import SomeParameters
 from launch_ros.remap_rule_type import RemapRules
-from launch_ros.remap_rule_type import SomeRemapRules
 from launch_ros.utilities import LifecycleEventManager
 
 from .composable_node import ComposableNode
@@ -34,6 +30,7 @@ from .composable_node import ComposableNode
 
 class ComposableLifecycleNode(ComposableNode):
     """Describes a lifecycle node that can be loaded into a container with other nodes."""
+
     def __init__(
         self, *,
         autostart: bool = False,

--- a/launch_ros/launch_ros/descriptions/composable_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_node.py
@@ -23,7 +23,6 @@ from launch.frontend import Entity
 from launch.frontend import Parser
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.substitution import Substitution
-# from launch.utilities import ensure_argument_type
 from launch.utilities import normalize_to_list_of_substitutions
 from launch_ros.parameters_type import Parameters
 from launch_ros.parameters_type import SomeParameters

--- a/launch_ros/launch_ros/descriptions/composable_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_node.py
@@ -17,6 +17,7 @@
 from typing import List
 from typing import Optional
 
+import launch
 from launch.condition import Condition
 from launch.conditions import IfCondition, UnlessCondition
 from launch.frontend import Entity
@@ -29,6 +30,7 @@ from launch_ros.parameters_type import Parameters
 from launch_ros.parameters_type import SomeParameters
 from launch_ros.remap_rule_type import RemapRules
 from launch_ros.remap_rule_type import SomeRemapRules
+from launch_ros.utilities import LifecycleEventManager
 from launch_ros.utilities import normalize_parameters
 from launch_ros.utilities import normalize_remap_rules
 
@@ -43,6 +45,7 @@ class ComposableNode:
         name: Optional[SomeSubstitutionsType] = None,
         namespace: Optional[SomeSubstitutionsType] = None,
         parameters: Optional[SomeParameters] = None,
+        autostart: Optional[bool] = False,
         remappings: Optional[SomeRemapRules] = None,
         extra_arguments: Optional[SomeParameters] = None,
         condition: Optional[Condition] = None,
@@ -83,6 +86,8 @@ class ComposableNode:
             self.__extra_arguments = normalize_parameters(extra_arguments)
 
         self.__condition = condition
+        self.__autostart = autostart
+        self.__lifecycle_event_manager = None
 
     @classmethod
     def parse(cls, parser: Parser, entity: Entity):
@@ -143,6 +148,10 @@ class ComposableNode:
 
         return cls, kwargs
 
+    def init_lifecycle_event_manager(self, node_name, context: launch.LaunchContext) -> None:
+        self.__lifecycle_event_manager = LifecycleEventManager(node_name)
+        self.__lifecycle_event_manager.setup_lifecycle_manager(context)
+
     @property
     def package(self) -> List[Substitution]:
         """Get node package name as a sequence of substitutions to be performed."""
@@ -162,6 +171,11 @@ class ComposableNode:
     def node_namespace(self) -> Optional[List[Substitution]]:
         """Get node namespace as a sequence of substitutions to be performed."""
         return self.__node_namespace
+
+    @property
+    def node_autostart(self):
+        """Getter for autostart."""
+        return self.__autostart
 
     @property
     def parameters(self) -> Optional[Parameters]:

--- a/launch_ros/launch_ros/descriptions/composable_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_node.py
@@ -164,11 +164,6 @@ class ComposableNode:
         return self.__node_namespace
 
     @property
-    def node_autostart(self):
-        """Getter for autostart."""
-        return False
-
-    @property
     def parameters(self) -> Optional[Parameters]:
         """Get node parameter YAML files or dicts with substitutions to be performed."""
         return self.__parameters

--- a/launch_ros/launch_ros/descriptions/composable_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_node.py
@@ -17,7 +17,6 @@
 from typing import List
 from typing import Optional
 
-import launch
 from launch.condition import Condition
 from launch.conditions import IfCondition, UnlessCondition
 from launch.frontend import Entity
@@ -30,7 +29,6 @@ from launch_ros.parameters_type import Parameters
 from launch_ros.parameters_type import SomeParameters
 from launch_ros.remap_rule_type import RemapRules
 from launch_ros.remap_rule_type import SomeRemapRules
-from launch_ros.utilities import LifecycleEventManager
 from launch_ros.utilities import normalize_parameters
 from launch_ros.utilities import normalize_remap_rules
 

--- a/launch_ros/launch_ros/descriptions/composable_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_node.py
@@ -45,7 +45,6 @@ class ComposableNode:
         name: Optional[SomeSubstitutionsType] = None,
         namespace: Optional[SomeSubstitutionsType] = None,
         parameters: Optional[SomeParameters] = None,
-        autostart: Optional[bool] = False,
         remappings: Optional[SomeRemapRules] = None,
         extra_arguments: Optional[SomeParameters] = None,
         condition: Optional[Condition] = None,
@@ -86,8 +85,6 @@ class ComposableNode:
             self.__extra_arguments = normalize_parameters(extra_arguments)
 
         self.__condition = condition
-        self.__autostart = autostart
-        self.__lifecycle_event_manager = None
 
     @classmethod
     def parse(cls, parser: Parser, entity: Entity):
@@ -148,10 +145,6 @@ class ComposableNode:
 
         return cls, kwargs
 
-    def init_lifecycle_event_manager(self, node_name, context: launch.LaunchContext) -> None:
-        self.__lifecycle_event_manager = LifecycleEventManager(node_name)
-        self.__lifecycle_event_manager.setup_lifecycle_manager(context)
-
     @property
     def package(self) -> List[Substitution]:
         """Get node package name as a sequence of substitutions to be performed."""
@@ -175,7 +168,7 @@ class ComposableNode:
     @property
     def node_autostart(self):
         """Getter for autostart."""
-        return self.__autostart
+        return False
 
     @property
     def parameters(self) -> Optional[Parameters]:

--- a/launch_ros/launch_ros/event_handlers/on_state_transition.py
+++ b/launch_ros/launch_ros/event_handlers/on_state_transition.py
@@ -14,7 +14,6 @@
 
 """Module for OnStateTransition class."""
 
-from inspect import getattr_static
 from typing import Callable
 from typing import Optional
 from typing import Text
@@ -51,14 +50,14 @@ class OnStateTransition(EventHandler):
 
         If matcher is given, the other conditions are not considered.
         """
-        target_lifecycle_property = type(target_lifecycle_node).__dict__.get('is_lifecycle_node', None)
-        if not isinstance(target_lifecycle_property, (property, type(None))):
-            raise RuntimeError("OnStateTransition requires a 'LifecycleNode' action as the target,"
-                               " target_lifecycle_node is not a node type.")
+        lifecycle_property = type(target_lifecycle_node).__dict__.get('is_lifecycle_node', None)
+        if not isinstance(lifecycle_property, (property, type(None))):
+            raise RuntimeError('OnStateTransition requires a "LifecycleNode" action as the target,'
+                               ' target_lifecycle_node is not a node type.')
 
         if target_lifecycle_node and not target_lifecycle_node.is_lifecycle_node:
-            raise RuntimeError("OnStateTransition requires a 'LifecycleNode' action as the target,"
-                               " target_lifecycle_node is not a lifecycle-enabled node.")
+            raise RuntimeError('OnStateTransition requires a "LifecycleNode" action as the target,'
+                               ' target_lifecycle_node is not a lifecycle-enabled node.')
 
         # Handle optional matcher argument.
         self.__custom_matcher = matcher

--- a/launch_ros/launch_ros/event_handlers/on_state_transition.py
+++ b/launch_ros/launch_ros/event_handlers/on_state_transition.py
@@ -14,6 +14,7 @@
 
 """Module for OnStateTransition class."""
 
+from inspect import getattr_static
 from typing import Callable
 from typing import Optional
 from typing import Text
@@ -23,7 +24,6 @@ from launch.event_handler import EventHandler
 from launch.some_entities_type import SomeEntitiesType
 from launch.some_substitutions_type import SomeSubstitutionsType
 
-from ..actions import LifecycleNode
 from ..events.lifecycle import StateTransition
 
 
@@ -34,7 +34,7 @@ class OnStateTransition(EventHandler):
         self,
         *,
         entities: SomeEntitiesType,
-        target_lifecycle_node: LifecycleNode = None,
+        target_lifecycle_node: Optional[SomeSubstitutionsType] = None,
         transition: Optional[SomeSubstitutionsType] = None,
         start_state: Optional[SomeSubstitutionsType] = None,
         goal_state: Optional[SomeSubstitutionsType] = None,
@@ -51,8 +51,15 @@ class OnStateTransition(EventHandler):
 
         If matcher is given, the other conditions are not considered.
         """
-        if not isinstance(target_lifecycle_node, (LifecycleNode, type(None))):
-            raise RuntimeError("OnStateTransition requires a 'LifecycleNode' action as the target")
+        target_lifecycle_property = type(target_lifecycle_node).__dict__.get('is_lifecycle_node', None)
+        if not isinstance(target_lifecycle_property, (property, type(None))):
+            raise RuntimeError("OnStateTransition requires a 'LifecycleNode' action as the target,"
+                               " target_lifecycle_node is not a node type.")
+
+        if target_lifecycle_node and not target_lifecycle_node.is_lifecycle_node:
+            raise RuntimeError("OnStateTransition requires a 'LifecycleNode' action as the target,"
+                               " target_lifecycle_node is not a lifecycle-enabled node.")
+
         # Handle optional matcher argument.
         self.__custom_matcher = matcher
         if self.__custom_matcher is None:

--- a/launch_ros/launch_ros/event_handlers/on_state_transition.py
+++ b/launch_ros/launch_ros/event_handlers/on_state_transition.py
@@ -50,8 +50,8 @@ class OnStateTransition(EventHandler):
 
         If matcher is given, the other conditions are not considered.
         """
-        lifecycle_property = type(target_lifecycle_node).__dict__.get('is_lifecycle_node', None)
-        if target_lifecycle_node and not isinstance(lifecycle_property, (property)):
+        from ..actions import LifecycleNode
+        if not isinstance(target_lifecycle_node, (LifecycleNode, type(None))):
             raise RuntimeError('OnStateTransition requires a lifecycle enabled node as the target,'
                                ' target_lifecycle_node is not a lifecycle-enabled node type.')
 

--- a/launch_ros/launch_ros/event_handlers/on_state_transition.py
+++ b/launch_ros/launch_ros/event_handlers/on_state_transition.py
@@ -33,7 +33,7 @@ class OnStateTransition(EventHandler):
         self,
         *,
         entities: SomeEntitiesType,
-        target_lifecycle_node: Optional['LifecycleNode'] = None,
+        target_lifecycle_node: Optional['LifecycleNode'] = None,  # noqa: F821
         transition: Optional[SomeSubstitutionsType] = None,
         start_state: Optional[SomeSubstitutionsType] = None,
         goal_state: Optional[SomeSubstitutionsType] = None,
@@ -51,17 +51,17 @@ class OnStateTransition(EventHandler):
         If matcher is given, the other conditions are not considered.
         """
         lifecycle_property = type(target_lifecycle_node).__dict__.get('is_lifecycle_node', None)
-        if not isinstance(lifecycle_property, (property, type(None))):
-            raise RuntimeError('OnStateTransition requires a "LifecycleNode" action as the target,'
-                               ' target_lifecycle_node is not a node type.')
+        if target_lifecycle_node and not isinstance(lifecycle_property, (property)):
+            raise RuntimeError('OnStateTransition requires a lifecycle enabled node as the target,'
+                               ' target_lifecycle_node is not a lifecycle-enabled node type.')
 
         if (
             target_lifecycle_node and
             hasattr(target_lifecycle_node, 'is_lifecycle_node') and
             not target_lifecycle_node.is_lifecycle_node
         ):
-            raise RuntimeError('OnStateTransition requires a "LifecycleNode" action as the target,'
-                               ' target_lifecycle_node is not a lifecycle-enabled node.')
+            raise RuntimeError('OnStateTransition requires a lifecycle enabled node as the target,'
+                               ' target_lifecycle_node is not lifecycle-enabled.')
 
         # Handle optional matcher argument.
         self.__custom_matcher = matcher

--- a/launch_ros/launch_ros/event_handlers/on_state_transition.py
+++ b/launch_ros/launch_ros/event_handlers/on_state_transition.py
@@ -33,7 +33,7 @@ class OnStateTransition(EventHandler):
         self,
         *,
         entities: SomeEntitiesType,
-        target_lifecycle_node: Optional[SomeSubstitutionsType] = None,
+        target_lifecycle_node: Optional['LifecycleNode'] = None,
         transition: Optional[SomeSubstitutionsType] = None,
         start_state: Optional[SomeSubstitutionsType] = None,
         goal_state: Optional[SomeSubstitutionsType] = None,

--- a/launch_ros/launch_ros/event_handlers/on_state_transition.py
+++ b/launch_ros/launch_ros/event_handlers/on_state_transition.py
@@ -55,7 +55,11 @@ class OnStateTransition(EventHandler):
             raise RuntimeError('OnStateTransition requires a "LifecycleNode" action as the target,'
                                ' target_lifecycle_node is not a node type.')
 
-        if target_lifecycle_node and not target_lifecycle_node.is_lifecycle_node:
+        if (
+            target_lifecycle_node and
+            hasattr(target_lifecycle_node, 'is_lifecycle_node') and
+            not target_lifecycle_node.is_lifecycle_node
+        ):
             raise RuntimeError('OnStateTransition requires a "LifecycleNode" action as the target,'
                                ' target_lifecycle_node is not a lifecycle-enabled node.')
 

--- a/launch_ros/launch_ros/utilities/__init__.py
+++ b/launch_ros/launch_ros/utilities/__init__.py
@@ -19,6 +19,7 @@ Descriptions are not executable and are immutable so they can be reused by launc
 """
 
 from .evaluate_parameters import evaluate_parameters
+from .lifecycle_event_manager import LifecycleEventManager
 from .namespace_utils import is_namespace_absolute
 from .namespace_utils import is_root_namespace
 from .namespace_utils import make_namespace_absolute
@@ -37,6 +38,7 @@ __all__ = [
     'get_node_name_count',
     'is_namespace_absolute',
     'is_root_namespace',
+    'LifecycleEventManager',
     'make_namespace_absolute',
     'normalize_parameters',
     'normalize_parameters_dict',

--- a/launch_ros/launch_ros/utilities/lifecycle_event_manager.py
+++ b/launch_ros/launch_ros/utilities/lifecycle_event_manager.py
@@ -31,6 +31,7 @@ from ..ros_adapters import get_ros_node
 
 
 class LifecycleEventManager:
+
     def __init__(self, name) -> None:
         """
         Construct a LifecycleEventManager utility.
@@ -57,7 +58,7 @@ class LifecycleEventManager:
         self.__node_name = name
         self.__rclpy_subscription = None
         self.__rclpy_change_state_client = None
-    
+
     @property
     def node_name(self):
         return self.__node_name

--- a/launch_ros/launch_ros/utilities/lifecycle_event_manager.py
+++ b/launch_ros/launch_ros/utilities/lifecycle_event_manager.py
@@ -1,0 +1,141 @@
+# Copyright 2024 Open Navigation LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for the management of LifecycleNode events."""
+
+import functools
+import threading
+from typing import cast
+
+import launch
+import launch.logging
+
+import lifecycle_msgs.msg
+import lifecycle_msgs.srv
+
+from ..events.lifecycle import ChangeState
+from ..events.lifecycle import StateTransition
+
+from ..ros_adapters import get_ros_node
+
+
+class LifecycleEventManager:
+    def __init__(self, name) -> None:
+        """
+        Construct a LifecycleEventManager utility.
+
+        This utility emits some event(s) in certain circumstances:
+
+        - :class:`launch.events.lifecycle.StateTransition`:
+
+            - this event is emitted when a message is published to the
+              "/<name>/transition_event" topic, indicating the lifecycle
+              node represented by this action changed state
+
+        This utility also handles some events related to lifecycle:
+
+        - :class:`launch.events.lifecycle.ChangeState`
+
+          - this event can be targeted to a single lifecycle node, or more than
+            one, or even all lifecycle nodes, and it requests the targeted nodes
+            to change state, see its documentation for more details.
+
+        :param name: The name of the lifecycle node.
+        """
+        self.__logger = launch.logging.get_logger(__name__)
+        self.__node_name = name
+        self.__rclpy_subscription = None
+        self.__rclpy_change_state_client = None
+    
+    @property
+    def node_name(self):
+        return self.__node_name
+
+    def _on_transition_event(self, context, msg):
+        try:
+            event = StateTransition(action=self, msg=msg)
+            context.asyncio_loop.call_soon_threadsafe(lambda: context.emit_event_sync(event))
+        except Exception as exc:
+            self.__logger.error(
+                "Exception in handling of 'lifecycle.msg.TransitionEvent': {}".format(exc))
+
+    def _call_change_state(self, request, context: launch.LaunchContext):
+        while not self.__rclpy_change_state_client.wait_for_service(timeout_sec=1.0):
+            if context.is_shutdown:
+                self.__logger.warning(
+                    "Abandoning wait for the '{}' service, due to shutdown.".format(
+                        self.__rclpy_change_state_client.srv_name),
+                )
+                return
+
+        # Asynchronously wait so that we can periodically check for shutdown.
+        event = threading.Event()
+
+        def unblock(future):
+            nonlocal event
+            event.set()
+
+        response_future = self.__rclpy_change_state_client.call_async(request)
+        response_future.add_done_callback(unblock)
+
+        while not event.wait(1.0):
+            if context.is_shutdown:
+                self.__logger.warning(
+                    "Abandoning wait for the '{}' service response, due to shutdown.".format(
+                        self.__rclpy_change_state_client.srv_name),
+                )
+                response_future.cancel()
+                return
+
+        if response_future.exception() is not None:
+            raise response_future.exception()
+        response = response_future.result()
+
+        if not response.success:
+            self.__logger.error(
+                "Failed to make transition '{}' for LifecycleNode '{}'".format(
+                    ChangeState.valid_transitions[request.transition.id],
+                    self.__node_name,
+                )
+            )
+
+    def _on_change_state_event(self, context: launch.LaunchContext) -> None:
+        typed_event = cast(ChangeState, context.locals.event)
+        if not typed_event.lifecycle_node_matcher(self):
+            return None
+        request = lifecycle_msgs.srv.ChangeState.Request()
+        request.transition.id = typed_event.transition_id
+        context.add_completion_future(
+            context.asyncio_loop.run_in_executor(None, self._call_change_state, request, context))
+
+    def setup_lifecycle_manager(self, context: launch.LaunchContext) -> None:
+        node = get_ros_node(context)
+
+        # Create a subscription to monitor the state changes of the subprocess.
+        self.__rclpy_subscription = node.create_subscription(
+            lifecycle_msgs.msg.TransitionEvent,
+            '{}/transition_event'.format(self.__node_name),
+            functools.partial(self._on_transition_event, context),
+            10)
+
+        # Create a service client to change state on demand.
+        self.__rclpy_change_state_client = node.create_client(
+            lifecycle_msgs.srv.ChangeState,
+            '{}/change_state'.format(self.__node_name))
+
+        # Register an event handler to change states on a ChangeState lifecycle event.
+        context.register_event_handler(launch.EventHandler(
+            matcher=lambda event: isinstance(event, ChangeState),
+            entities=[launch.actions.OpaqueFunction(function=self._on_change_state_event)],
+        ))

--- a/launch_ros/launch_ros/utilities/lifecycle_event_manager.py
+++ b/launch_ros/launch_ros/utilities/lifecycle_event_manager.py
@@ -52,7 +52,7 @@ class LifecycleEventManager:
             one, or even all lifecycle nodes, and it requests the targeted nodes
             to change state, see its documentation for more details.
 
-        :param name: The name of the lifecycle node.
+        :param lifecycle_node: The lifecycle node to event manage.
         """
         self.__logger = launch.logging.get_logger(__name__)
         self.__lifecycle_node = lifecycle_node

--- a/launch_ros/launch_ros/utilities/lifecycle_event_manager.py
+++ b/launch_ros/launch_ros/utilities/lifecycle_event_manager.py
@@ -63,12 +63,9 @@ class LifecycleEventManager:
     def node_name(self):
         return self.__lifecycle_node.node_name
 
-    def __eq__(self, other):
-        return self.__lifecycle_node == other
-
     def _on_transition_event(self, context, msg):
         try:
-            event = StateTransition(action=self, msg=msg)
+            event = StateTransition(action=self.__lifecycle_node, msg=msg)
             context.asyncio_loop.call_soon_threadsafe(lambda: context.emit_event_sync(event))
         except Exception as exc:
             self.__logger.error(
@@ -116,8 +113,9 @@ class LifecycleEventManager:
 
     def _on_change_state_event(self, context: launch.LaunchContext) -> None:
         typed_event = cast(ChangeState, context.locals.event)
-        if not typed_event.lifecycle_node_matcher(self):
+        if not typed_event.lifecycle_node_matcher(self.__lifecycle_node):
             return None
+        print('Ju lee, were doing the thing!')
         request = lifecycle_msgs.srv.ChangeState.Request()
         request.transition.id = typed_event.transition_id
         context.add_completion_future(

--- a/launch_ros/launch_ros/utilities/lifecycle_event_manager.py
+++ b/launch_ros/launch_ros/utilities/lifecycle_event_manager.py
@@ -115,7 +115,6 @@ class LifecycleEventManager:
         typed_event = cast(ChangeState, context.locals.event)
         if not typed_event.lifecycle_node_matcher(self.__lifecycle_node):
             return None
-        print('Ju lee, were doing the thing!')
         request = lifecycle_msgs.srv.ChangeState.Request()
         request.transition.id = typed_event.transition_id
         context.add_completion_future(

--- a/test_launch_ros/test/test_launch_ros/actions/test_lifecycle_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_lifecycle_node.py
@@ -41,7 +41,13 @@ def test_lifecycle_node_constructor():
         name='my_node',
         namespace='my_ns',
     )
-
+    LifecycleNode(
+        package='asd',
+        executable='bsd',
+        name='my_node',
+        namespace='my_ns',
+        autostart=True,
+    )
 
 def test_node_name():
     node_object = LifecycleNode(

--- a/test_launch_ros/test/test_launch_ros/actions/test_lifecycle_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_lifecycle_node.py
@@ -49,6 +49,7 @@ def test_lifecycle_node_constructor():
         autostart=True,
     )
 
+
 def test_node_name():
     node_object = LifecycleNode(
         package='asd',


### PR DESCRIPTION
This resolves #418 which implements autostarting lifecycle nodes. This is complete and ready for a review 

You'll notice a couple of key changes worth explaining:

1. There is a new `is_lifecycle_node` attribute of the node and lifecycle nodes which is needed to remove a circular dependency on the LifecycleNode within the `LifecycleTransition` class which only is type checking. I replace this type check with checking if a non-None object (1) has the attribute at all and (2) has a lifecycle attribute with appropriate logging between the difference of a non-lifecycle node being attempted vs a non-node. This has been tested as well to function using the demos. 

2. You will also notice that I refactored lifecycle node to have a separate util `LifecycleEventManager`, who handles the event emitting, handling, and topic listening for lifecycle nodes. This way, this can be used in lifecycle-components as well! No changes were made here except removing the `self.__current_state` variable which was completely unused. The `LifecycleEventManager` is only created if the node requests autostart at Launch time and otherwise has no overhead nor exposes the interfaces/event handler/emitter if its a non-lifecycle node. 

3. The component nodes don't add a `/` before the node names with the namespaces. This messes with the node event matcher. I add in a leading `/` so that the `action.node_name == node_name` which has the `/` forcably applied in the node event matcher 

4. I tested `LifecycleNode`, `ComposableNodeContainer`, `LoadCompoableNodes` for all cases: `autostart=True` `autostart=False`, and `autostart` field not supplied. You can also run any experiments you like using the 2 extra launch files I provide in the examples directory which shows all the features at work/ 