### PR TITLE
Fix function params indentation

### DIFF
--- a/launch_testing_ros/launch_testing_ros/wait_for_topics.py
+++ b/launch_testing_ros/launch_testing_ros/wait_for_topics.py
@@ -52,7 +52,7 @@ class WaitForTopics:
             wait_for_topics.shutdown()
     """
 
-    def __init__(self, topic_tuples, timeout=5.0, messages_received_buffer_length=10):
+    def __init__(self, topic_tuples, timeout=5.0, messages_received_buffer_length=10) -> None:
         self.topic_tuples = topic_tuples
         self.timeout = timeout
         self.messages_received_buffer_length = messages_received_buffer_length
@@ -121,8 +121,8 @@ class _WaitForTopicsNode(Node):
     """Internal node used for subscribing to a set of topics."""
 
     def __init__(
-            self, name='test_node', node_context=None, messages_received_buffer_length=None
-    ):
+        self, name='test_node', node_context=None, messages_received_buffer_length=None
+    ) -> None:
         super().__init__(node_name=name, context=node_context)  # type: ignore
         self.msg_event_object = Event()
         self.messages_received_buffer_length = messages_received_buffer_length


### PR DESCRIPTION
And add return type.

This is what I could find with a quick search, but there might be more.