### PR TITLE
Fixing lifecycle node autostart issue #445

### DIFF
--- a/launch_ros/launch_ros/actions/lifecycle_node.py
+++ b/launch_ros/launch_ros/actions/lifecycle_node.py
@@ -107,11 +107,8 @@ class LifecycleNode(Node):
             autostart_actions = [
                 LifecycleTransition(
                     lifecycle_node_names=[self.node_name],
-                    transition_ids=[lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE]
-                ),
-                LifecycleTransition(
-                    lifecycle_node_names=[self.node_name],
-                    transition_ids=[lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE]
+                    transition_ids=[lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE,
+                                    lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE]
                 ),
             ]
 

--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -251,14 +251,9 @@ class LoadComposableNodes(Action):
                 autostart_actions.append(
                     LifecycleTransition(
                         lifecycle_node_names=[complete_node_name],
-                        transition_ids=[lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE]
+                        transition_ids=[lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE,
+                                        lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE]
                     ))
-                autostart_actions.append(
-                    LifecycleTransition(
-                        lifecycle_node_names=[complete_node_name],
-                        transition_ids=[lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE]
-                    ),
-                )
 
         if load_node_requests:
             context.add_completion_future(


### PR DESCRIPTION
Fixing lifecycle node autostart issue #445 

The issue boils down to the emitting of signals for the first transition in the `transition_ids`. It appears that sometimes the Launch system doesn't emit these in order or for whatever reason the second signal is received by the server before the first. By putting them both in a single transition, only the configure signal is emitted and activate is dependent fully on the state transition.

Honestly, this is probably how it should have always been implemented, but I didn't think it mattered at the time since I thought ordering was guaranteed. 