### PR TITLE
Change docstring markdown code blocks to RST

### DIFF
--- a/launch_ros/launch_ros/actions/set_parameter.py
+++ b/launch_ros/launch_ros/actions/set_parameter.py
@@ -35,8 +35,11 @@ class SetParameter(Action):
     Action that sets a parameter in the current context.
 
     This parameter will be set in all the nodes launched in the same scope.
-    e.g.:
-    ```python3
+
+    For example:
+
+    .. code-block:: python
+
         LaunchDescription([
             ...,
             GroupAction(
@@ -44,14 +47,13 @@ class SetParameter(Action):
                     ...,
                     SetParameter(name='my_param', value='2'),
                     ...,
-                    Node(...),  // the param will be passed to this node
+                    Node(...),  # the param will be passed to this node
                     ...,
                 ]
             ),
-            Node(...),  // here it won't be passed, as it's not in the same scope
+            Node(...),  # here it won't be passed, as it's not in the same scope
             ...
         ])
-    ```
     """
 
     def __init__(

--- a/launch_ros/launch_ros/actions/set_parameters_from_file.py
+++ b/launch_ros/launch_ros/actions/set_parameters_from_file.py
@@ -29,8 +29,10 @@ class SetParametersFromFile(Action):
     """
     Action that sets parameters for all nodes in scope based on a given yaml file.
 
-    e.g.
-    ```python3
+    For example:
+
+    .. code-block:: python
+
         LaunchDescription([
             ...,
             GroupAction(
@@ -38,24 +40,23 @@ class SetParametersFromFile(Action):
                     ...,
                     SetParametersFromFile('path/to/file.yaml'),
                     ...,
-                    Node(...),  // the params will be passed to this node
+                    Node(...),  # the params will be passed to this node
                     ...,
                 ]
             ),
-            Node(...),  // here it won't be passed, as it's not in the same scope
+            Node(...),  # here it won't be passed, as it's not in the same scope
             ...
         ])
-    ```
-    ```xml
-    <launch>
-        <group>
-            <set_parameters_from_file filename='/path/to/file.yaml'/>
-            <node .../>    // Node in scope, params will be passed
-        </group>
-        <node .../>  // Node not in scope, params won't be passed
-    </launch>
 
-    ```
+    .. code-block:: xml
+
+        <launch>
+            <group>
+                <set_parameters_from_file filename='/path/to/file.yaml'/>
+                <node .../>  <!-- Node in scope, params will be passed -->
+            </group>
+            <node .../>  <!-- Node not in scope, params won't be passed -->
+        </launch>
     """
 
     def __init__(

--- a/launch_ros/launch_ros/actions/set_remap.py
+++ b/launch_ros/launch_ros/actions/set_remap.py
@@ -34,8 +34,11 @@ class SetRemap(Action):
 
     This remapping rule will be passed to all the nodes launched in the same scope, overriding
     the ones specified in the `Node` action constructor.
-    e.g.:
-    ```python3
+
+    For example:
+
+    .. code-block:: python
+
         LaunchDescription([
             ...,
             GroupAction(
@@ -43,14 +46,13 @@ class SetRemap(Action):
                     ...,
                     SetRemap(src='asd', dst='bsd'),
                     ...,
-                    Node(...),  // the remap rule will be passed to this node
+                    Node(...),  # the remap rule will be passed to this node
                     ...,
                 ]
             ),
-            Node(...),  // here it won't be passed, as it's not in the same scope
+            Node(...),  # here it won't be passed, as it's not in the same scope
             ...
         ])
-    ```
     """
 
     def __init__(

--- a/launch_ros/launch_ros/utilities/namespace_utils.py
+++ b/launch_ros/launch_ros/utilities/namespace_utils.py
@@ -47,24 +47,24 @@ def prefix_namespace(
         `ns` prefixed with `base_ns`.
         In all cases, trailing `/` are stripped from the result.
 
-    ## Examples:
+    For example:
 
-    ```python3
-    combined_ns = prefix_namespace('my_ns', 'original_ns')
-    assert combined_ns == 'my_ns/original_ns'
+    .. code-block:: python
 
-    combined_ns = prefix_namespace('/my_ns', 'original_ns')
-    assert combined_ns == '/my_ns/original_ns'
+        combined_ns = prefix_namespace('my_ns', 'original_ns')
+        assert combined_ns == 'my_ns/original_ns'
 
-    combined_ns = prefix_namespace('my_ns', '/original_ns')
-    assert combined_ns == '/original_ns'
+        combined_ns = prefix_namespace('/my_ns', 'original_ns')
+        assert combined_ns == '/my_ns/original_ns'
 
-    combined_ns = prefix_namespace(None, 'original_ns')
-    assert combined_ns == 'original_ns'
+        combined_ns = prefix_namespace('my_ns', '/original_ns')
+        assert combined_ns == '/original_ns'
 
-    combined_ns = prefix_namespace('my_ns', None)
-    assert combined_ns == 'my_ns'
-    ```
+        combined_ns = prefix_namespace(None, 'original_ns')
+        assert combined_ns == 'original_ns'
+
+        combined_ns = prefix_namespace('my_ns', None)
+        assert combined_ns == 'my_ns'
     """
     combined_ns: Optional[Text] = None
     if base_ns is not None or ns is not None:


### PR DESCRIPTION
The API docs are currently a bit messed up because of markdown code blocks:

![image](https://github.com/user-attachments/assets/4f51583d-352f-477c-a636-f506133bcc9e)

1. https://docs.ros.org/en/rolling/p/launch_ros/launch_ros.actions.set_parameter.html#launch_ros.actions.set_parameter.SetParameter
2. https://docs.ros.org/en/rolling/p/launch_ros/launch_ros.actions.set_parameters_from_file.html#launch_ros.actions.set_parameters_from_file.SetParametersFromFile
3. https://docs.ros.org/en/rolling/p/launch_ros/launch_ros.actions.set_remap.html#launch_ros.actions.set_remap.SetRemap
4. https://docs.ros.org/en/rolling/p/launch_ros/launch_ros.utilities.namespace_utils.html#launch_ros.utilities.namespace_utils.prefix_namespace

These should be RST code blocks. Also, adapt comments.