### PR TITLE
Add launch_testing_ros_ament_cmake package

### DIFF
--- a/launch_testing_ros/launch_testing_ros/launch_test.py
+++ b/launch_testing_ros/launch_testing_ros/launch_test.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+
+from launch_testing.launch_test import parse_arguments
+from launch_testing.launch_test import run
+from launch_testing_ros.test_runner import LaunchTestRunner
+
+_logger_ = logging.getLogger(__name__)
+
+
+def main():
+    logging.basicConfig()
+
+    parser, args = parse_arguments()
+
+    if args.verbose:
+        _logger_.setLevel(logging.DEBUG)
+        _logger_.debug('Running with verbose output')
+
+    try:
+        sys.exit(run(parser, args, test_runner_cls=LaunchTestRunner))
+    except Exception as e:
+        parser.error(e)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/launch_testing_ros_ament_cmake/CMakeLists.txt
+++ b/launch_testing_ros_ament_cmake/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.5)
+project(launch_testing_ros_ament_cmake)
+
+find_package(ament_cmake REQUIRED)
+
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  find_package(launch_testing_ament_cmake REQUIRED)
+  include(cmake/add_launch_ros_test.cmake)
+
+  ament_index_has_resource(LAUNCH_TESTING_INSTALL_PREFIX packages launch_testing)
+  if(NOT LAUNCH_TESTING_INSTALL_PREFIX)
+      message(FATAL_ERROR "launch_testing package not found")
+  endif()
+
+  # Test argument passing.  This test won't pass unless you give it an argument
+  add_launch_ros_test(
+    "${LAUNCH_TESTING_INSTALL_PREFIX}/share/launch_testing/examples/args_launch_test.py"
+    ARGS "dut_arg:=--anything"
+  )
+endif()
+
+ament_export_dependencies(launch_testing_ament_cmake)
+
+ament_package(
+  CONFIG_EXTRAS "${PROJECT_NAME}-extras.cmake"
+)

--- a/launch_testing_ros_ament_cmake/cmake/add_launch_ros_test.cmake
+++ b/launch_testing_ros_ament_cmake/cmake/add_launch_ros_test.cmake
@@ -1,0 +1,28 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Add a launch ROS test
+#
+# Parameters are the same as add_launch_test
+
+function(add_launch_ros_test filename)
+
+  add_launch_test(
+    "${filename}"
+    RUNNER_MODULE "launch_testing_ros.launch_test"
+    ${ARGN}
+  )
+
+endfunction()

--- a/launch_testing_ros_ament_cmake/launch_testing_ros_ament_cmake-extras.cmake
+++ b/launch_testing_ros_ament_cmake/launch_testing_ros_ament_cmake-extras.cmake
@@ -1,0 +1,15 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include("${launch_testing_ros_ament_cmake_DIR}/add_launch_ros_test.cmake")

--- a/launch_testing_ros_ament_cmake/package.xml
+++ b/launch_testing_ros_ament_cmake/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>launch_testing_ros_ament_cmake</name>
+  <version>0.28.0</version>
+  <description>A package providing cmake functions for running ROS 2 enabled launch tests from the build.</description>
+
+  <maintainer email="aditya.pande@openrobotics.org">Aditya Pande</maintainer>
+  <maintainer email="brandon@openrobotics.org">Brandon Ong</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <author email="logans@cottsay.net">Scott K Logan</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <buildtool_export_depend>launch_testing_ament_cmake</buildtool_export_depend>
+  <buildtool_export_depend>launch_testing_ros</buildtool_export_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
This package complements the functionality of `launch_testing_ament_cmake` but uses `launch_testing_ros` for actually running the test.

Requires ros2/launch#854