### PR TITLE
Add EnableRmwIsolation action for starting rmw_test_fixture

### DIFF
--- a/launch_testing_ros/launch_testing_ros/actions/__init__.py
+++ b/launch_testing_ros/launch_testing_ros/actions/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .enable_rmw_isolation import EnableRmwIsolation
+
+__all__ = [
+    'EnableRmwIsolation',
+]

--- a/launch_testing_ros/launch_testing_ros/actions/enable_rmw_isolation.py
+++ b/launch_testing_ros/launch_testing_ros/actions/enable_rmw_isolation.py
@@ -37,7 +37,5 @@ class EnableRmwIsolation(Action):
 
     def execute(self, context: LaunchContext) -> Optional[List[LaunchDescriptionEntity]]:
         rmw_test_isolation_start()
-        import os
-        print(f"ENABLED ISOLATION FOR {os.environ.get('RMW_IMPLEMENTATION')}")
         context.register_event_handler(OnShutdown(
             on_shutdown=self.__on_shutdown))

--- a/launch_testing_ros/launch_testing_ros/actions/enable_rmw_isolation.py
+++ b/launch_testing_ros/launch_testing_ros/actions/enable_rmw_isolation.py
@@ -1,0 +1,43 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+from typing import Optional
+
+from launch.action import Action
+from launch.event import Event
+from launch.event_handlers import OnShutdown
+from launch.launch_context import LaunchContext
+from launch.launch_description_entity import LaunchDescriptionEntity
+from launch.some_entities_type import SomeEntitiesType
+from rmw_test_fixture_implementation import rmw_test_isolation_start
+from rmw_test_fixture_implementation import rmw_test_isolation_stop
+
+
+class EnableRmwIsolation(Action):
+    """Action which enables isolation of ROS communication using rmw_test_fixture."""
+
+    def __init__(self, **kwargs) -> None:
+        """Create a EnableRmwIsolation action."""
+        super().__init__(**kwargs)
+
+    def __on_shutdown(self, event: Event, context: LaunchContext) -> Optional[SomeEntitiesType]:
+        rmw_test_isolation_stop()
+
+    def execute(self, context: LaunchContext) -> Optional[List[LaunchDescriptionEntity]]:
+        rmw_test_isolation_start()
+        import os
+        print(f"ENABLED ISOLATION FOR {os.environ.get('RMW_IMPLEMENTATION')}")
+        context.register_event_handler(OnShutdown(
+            on_shutdown=self.__on_shutdown))

--- a/launch_testing_ros/package.xml
+++ b/launch_testing_ros/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>launch_testing</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>rmw_test_fixture_implementation</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
This action allows a test to engage the `rmw_test_fixture` to isolate ROS communication for processes created after the action is executed.

The isolation is cleaned up when launch shuts down, but because all existing isolation mechanisms rely on environment variables for configuring ROS and underlying RMW communication, enabling isolation within any sort of `GroupAction` will reset the environment variables when the scope exits.