### PR TITLE
Scoped Include compatibility

### DIFF
--- a/launch_ros/launch_ros/actions/push_ros_namespace.py
+++ b/launch_ros/launch_ros/actions/push_ros_namespace.py
@@ -26,6 +26,7 @@ from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.substitutions import SubstitutionFailure
 from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
+from launch.utilities import register_global
 
 from launch_ros.utilities import make_namespace_absolute
 from launch_ros.utilities import prefix_namespace
@@ -79,4 +80,5 @@ class PushROSNamespace(Action):
                     previous_namespace, pushed_namespace
                 )
             )
+        register_global(context, 'ros_namespace')
         context.launch_configurations['ros_namespace'] = namespace

--- a/launch_ros/launch_ros/actions/set_remap.py
+++ b/launch_ros/launch_ros/actions/set_remap.py
@@ -25,6 +25,7 @@ from launch.launch_context import LaunchContext
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
+from launch.utilities import register_global
 
 
 @expose_action('set_remap')
@@ -90,4 +91,5 @@ class SetRemap(Action):
         dst = perform_substitutions(context, self.__dst)
         global_remaps = context.launch_configurations.get('ros_remaps', [])
         global_remaps.append((src, dst))
+        register_global(context, 'ros_remaps')
         context.launch_configurations['ros_remaps'] = global_remaps

--- a/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_push_ros_namespace.py
@@ -14,6 +14,10 @@
 
 """Tests for the PushROSNamespace Action."""
 
+from typing import Any
+from typing import Dict
+from typing import Text
+
 from launch_ros.actions import Node
 from launch_ros.actions import PushROSNamespace
 from launch_ros.actions.load_composable_nodes import get_composable_node_load_request
@@ -26,9 +30,37 @@ class MockContext:
 
     def __init__(self):
         self.launch_configurations = {}
+        self.__locals = {}
 
     def perform_substitution(self, sub):
         return sub.perform(None)
+
+    @property  # noqa: A003
+    def locals(self):  # noqa: A003
+        """Getter for the locals."""
+        class AttributeDict:
+
+            def __init__(self, dict_in):
+                self.__dict__['__dict'] = dict_in
+
+            def __getattr__(self, key):
+                _dict = self.__dict__['__dict']
+                if key not in _dict:
+                    raise AttributeError(
+                        "context.locals does not contain attribute '{}', it contains: [{}]".format(
+                            key,
+                            ', '.join(_dict.keys())
+                        )
+                    )
+                return _dict[key]
+
+            def __setattr__(self, key, value):
+                raise AttributeError("can't set attribute '{}', locals are read-only".format(key))
+
+        return AttributeDict(self.__locals)
+
+    def extend_locals(self, extension: Dict[Text, Any]) -> None:
+        self.__locals.update(extension)
 
 
 class Config:

--- a/test_launch_ros/test/test_launch_ros/actions/test_set_remap.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_set_remap.py
@@ -14,6 +14,10 @@
 
 """Tests for the SetRemap Action."""
 
+from typing import Any
+from typing import Dict
+from typing import Text
+
 from launch import LaunchContext
 from launch.actions import PopLaunchConfigurations
 from launch.actions import PushLaunchConfigurations
@@ -30,9 +34,37 @@ class MockContext:
 
     def __init__(self):
         self.launch_configurations = {}
+        self.__locals = {}
 
     def perform_substitution(self, sub):
         return sub.perform(None)
+
+    @property  # noqa: A003
+    def locals(self):  # noqa: A003
+        """Getter for the locals."""
+        class AttributeDict:
+
+            def __init__(self, dict_in):
+                self.__dict__['__dict'] = dict_in
+
+            def __getattr__(self, key):
+                _dict = self.__dict__['__dict']
+                if key not in _dict:
+                    raise AttributeError(
+                        "context.locals does not contain attribute '{}', it contains: [{}]".format(
+                            key,
+                            ', '.join(_dict.keys())
+                        )
+                    )
+                return _dict[key]
+
+            def __setattr__(self, key, value):
+                raise AttributeError("can't set attribute '{}', locals are read-only".format(key))
+
+        return AttributeDict(self.__locals)
+
+    def extend_locals(self, extension: Dict[Text, Any]) -> None:
+        self.__locals.update(extension)
 
 
 def get_set_remap_test_remaps():


### PR DESCRIPTION
Updates `PushROSNamespace` and `SetRemap` to behave intuitively when used in conjunction with Scoped Includes.

Their internal launch configuration is added to the list to keep and be passed into the inner scope.

Requires ros2/launch#841