### PR TITLE
Fix: LoadComposableNodes fails to parse wildcard param files correctl…

### DIFF
--- a/launch_ros/launch_ros/utilities/to_parameters_list.py
+++ b/launch_ros/launch_ros/utilities/to_parameters_list.py
@@ -15,6 +15,7 @@
 """Module with utility to transform evaluated parameters into parameter lists."""
 
 import pathlib
+import re
 from typing import List
 import warnings
 
@@ -56,6 +57,12 @@ def __normalize_parameters_dict(dictionary):
     return normalize_parameters_dict(dictionary, [], {})
 
 
+def is_node_name_matched(node_name: str, node_fqn: str) -> bool:
+    # Will match ["/*" -> "(/\\w+)" and "/**" -> "(/\\w+)*"]
+    regex = node_name.replace('/*', '(/\\w+)')
+    return bool(re.fullmatch(regex, node_fqn))
+
+
 def to_parameters_list(
     context: LaunchContext,
     node_name: str,
@@ -89,8 +96,9 @@ def to_parameters_list(
 
                 if normalized_param_dict:
                     param_dict.clear()
-                    if '**' in normalized_param_dict:
-                        param_dict = normalized_param_dict['**']
+                    for key in normalized_param_dict:
+                        if (is_node_name_matched(f'/{key}', f'/{node_name}')):
+                            param_dict.update(normalized_param_dict[key])
                     if node_name in normalized_param_dict:
                         param_dict.update(normalized_param_dict[node_name])
                     if not warned_once and not node_name:

--- a/test_launch_ros/test/test_launch_ros/actions/example_parameters_multiple_entries.yaml
+++ b/test_launch_ros/test/test_launch_ros/actions/example_parameters_multiple_entries.yaml
@@ -9,6 +9,10 @@
     param_2: 22
     param_3: 33
 
+/*/node_1:
+  ros__parameters:
+    param_4: 4
+
 ns_2/node_2:
     ros__parameters:
       param_3: 3

--- a/test_launch_ros/test/test_launch_ros/actions/example_parameters_wildcard_mixed.yaml
+++ b/test_launch_ros/test/test_launch_ros/actions/example_parameters_wildcard_mixed.yaml
@@ -1,0 +1,3 @@
+/*/aa/**/my_node:
+  ros__parameters:
+    param: "wildcard"

--- a/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
@@ -387,13 +387,15 @@ def test_load_node_with_param_file(mock_component_container):
     assert get_node_name_count(context, '/ns_1/node_1') == 1
     assert request.node_name == 'node_1'
     assert request.node_namespace == '/ns_1'
-    assert len(request.parameters) == 3
-    assert request.parameters[0].name == 'param_2'
-    assert request.parameters[0].value.integer_value == 2
-    assert request.parameters[1].name == 'param_3'
-    assert request.parameters[1].value.integer_value == 33
-    assert request.parameters[2].name == 'param_1'
-    assert request.parameters[2].value.integer_value == 1
+    assert len(request.parameters) == 4
+    assert request.parameters[0].name == 'param_1'
+    assert request.parameters[0].value.integer_value == 1
+    assert request.parameters[1].name == 'param_2'
+    assert request.parameters[1].value.integer_value == 2
+    assert request.parameters[2].name == 'param_3'
+    assert request.parameters[2].value.integer_value == 33
+    assert request.parameters[3].name == 'param_4'
+    assert request.parameters[3].value.integer_value == 4
 
     request = mock_component_container.requests[-1]
     assert get_node_name_count(context, '/ns_2/node_2') == 1
@@ -468,6 +470,26 @@ def test_load_node_with_param_file(mock_component_container):
     assert request.node_name == 'wrong_node_name'
     assert request.node_namespace == '/ns'
     assert len(request.parameters) == 0
+
+    # Case 9: wildcard mixed
+    context = _assert_launch_no_errors([
+        _load_composable_node(
+            package='foo_package',
+            plugin='bar_plugin',
+            name='my_node',
+            namespace='/wildcard_ns/aa/extra1/extra2',
+            parameters=[
+                parameters_file_dir / 'example_parameters_wildcard_mixed.yaml'
+            ],
+        )
+    ])
+    request = mock_component_container.requests[-1]
+    assert get_node_name_count(context, '/wildcard_ns/aa/extra1/extra2/my_node') == 1
+    assert request.node_name == 'my_node'
+    assert request.node_namespace == '/wildcard_ns/aa/extra1/extra2'
+    assert len(request.parameters) == 1
+    assert request.parameters[0].name == 'param'
+    assert request.parameters[0].value.string_value == 'wildcard'
 
     # Namespace not found
     context = _assert_launch_no_errors([


### PR DESCRIPTION
…y (#460)

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Ported the [function](https://github.com/ros2/rclcpp/blob/f3d66b892e6a7931ac2dbf3d2e5c0c1558312e10/rclcpp/src/rclcpp/parameter_map.cpp#L28-L33) to python. And used it properly for fixing the bug.
Fixes #460 

### Is this user-facing behavior change?

Yes, users will now see parameters like `param1` being correctly loaded from the parameter file when using a `ComposableNode` action.


1. ComposableNode action
```
ComposableNode(
    package="pkg",
    plugin="NodeCls",
    name="bar",
    namespace="foo",
    parameters=["path-to-params-file"],
)
```
2. param file:
```
/*/bar:
     ros__parameters:
       param1: 500
```
param1 will be loaded correctly after fix more info about bug (#460)


### Did you use Generative AI?

no

### Additional Information

