### PR TITLE
Improve readability when printing type of classes in error messages

### DIFF
--- a/launch_ros/launch_ros/parameter_descriptions.py
+++ b/launch_ros/launch_ros/parameter_descriptions.py
@@ -83,7 +83,7 @@ class ParameterValue:
     def __str__(self) -> Text:
         return (
             'launch_ros.description.ParameterValue'
-            f'(value={self.value}, value_type={self.value_type})'
+            f'(value={self.value}, value_type={self.value_type.__name__})'
         )
 
     def evaluate(self, context: LaunchContext) -> 'EvaluatedParameterValue':
@@ -148,7 +148,7 @@ class Parameter:
     def __str__(self) -> Text:
         return (
             'launch_ros.description.Parameter'
-            f'(name={self.name}, value={self.value}, value_type={self.value_type})'
+            f'(name={self.name}, value={self.value}, value_type={self.value_type.__name__})'
         )
 
     def evaluate(self, context: LaunchContext) -> Tuple[Text, 'EvaluatedParameterValue']:

--- a/launch_ros/launch_ros/utilities/evaluate_parameters.py
+++ b/launch_ros/launch_ros/utilities/evaluate_parameters.py
@@ -104,7 +104,7 @@ def evaluate_parameter_dict(
                         'If the parameter is meant to be a string, try wrapping it in '
                         'launch_ros.parameter_descriptions.ParameterValue'
                         '(value, value_type=str)'.format(
-                            type(yaml_evaluated_value),
+                            type(yaml_evaluated_value).__name__,
                             evaluated_name
                         )
                     )


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

Similar to https://github.com/ros2/launch/pull/887, in a few places, error messages printed types in a verbose format like '<class 'str'>'. This PR simplifies that by displaying just the type name (e.g. 'str').

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

<!--
### Is this user-facing behavior change?


If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
### Additional Information


If applicable, provide any additional context or details about the changes.
-->
