### PR TITLE
use locals instead of launch configurations to store ros_remaps and ros_namespace

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -400,7 +400,7 @@ class Node(ExecuteProcess):
             if self.__node_namespace is not None:
                 expanded_node_namespace = perform_substitutions(
                     context, normalize_to_list_of_substitutions(self.__node_namespace))
-            base_ns = context.launch_configurations.get('ros_namespace', None)
+            base_ns = context.get_locals_as_dict().get('ros_namespace', None)
             expanded_node_namespace = make_namespace_absolute(
                 prefix_namespace(base_ns, expanded_node_namespace))
             if expanded_node_namespace is not None:
@@ -468,7 +468,7 @@ class Node(ExecuteProcess):
                 cmd_extension = ['--params-file' if is_file else '-p', f'{param_argument}']
                 self.cmd.extend([normalize_to_list_of_substitutions(x) for x in cmd_extension])
         # expand remappings too
-        global_remaps = context.launch_configurations.get('ros_remaps', None)
+        global_remaps = context.get_locals_as_dict().get('ros_remaps', None)
         if global_remaps or self.__remappings:
             self.__expanded_remappings = []
         if global_remaps:

--- a/launch_ros/launch_ros/actions/push_ros_namespace.py
+++ b/launch_ros/launch_ros/actions/push_ros_namespace.py
@@ -67,7 +67,7 @@ class PushROSNamespace(Action):
     def execute(self, context: LaunchContext):
         """Execute the action."""
         pushed_namespace = perform_substitutions(context, self.namespace)
-        previous_namespace = context.launch_configurations.get('ros_namespace', None)
+        previous_namespace = context.get_locals_as_dict().get('ros_namespace', None)
         namespace = make_namespace_absolute(
             prefix_namespace(previous_namespace, pushed_namespace))
         try:
@@ -79,4 +79,4 @@ class PushROSNamespace(Action):
                     previous_namespace, pushed_namespace
                 )
             )
-        context.launch_configurations['ros_namespace'] = namespace
+        context.extend_locals({'ros_namespace': namespace})

--- a/launch_ros/launch_ros/actions/set_remap.py
+++ b/launch_ros/launch_ros/actions/set_remap.py
@@ -88,6 +88,6 @@ class SetRemap(Action):
         """Execute the action."""
         src = perform_substitutions(context, self.__src)
         dst = perform_substitutions(context, self.__dst)
-        global_remaps = context.launch_configurations.get('ros_remaps', [])
+        global_remaps = context.get_locals_as_dict().get('ros_remaps', [])
         global_remaps.append((src, dst))
-        context.launch_configurations['ros_remaps'] = global_remaps
+        context.extend_locals({'ros_remaps': global_remaps})


### PR DESCRIPTION
## Description
ros_remaps and ros_namespace are currently stored as launch configurations, but they don't behave like typical launch configurations — they're not declared using DeclareLaunchArgument, and their purpose is more aligned with contextual scoping.

They are better suited to be stored in the local stack (locals()) of the LaunchContext, rather than in the global launch configurations. This distinction aligns better with their use as scoped contextual variables rather than user-defined launch arguments.

This change is related to the discussion in [ros2/launch#801 (comment)](https://github.com/ros2/launch/issues/801#issuecomment-2975646031), where a workaround was proposed to distinguish between launch configurations that should be scoped versus those that should propagate globally.

This PR is marked as a draft because I haven't found definitive guidance in launch_ros or [ros2/design](https://github.com/ros2/design) regarding the intended semantics of the locals and globals stacks within LaunchContext. Based on my understanding, this usage seems appropriate, but I welcome feedback if this assumption is incorrect.

### Did you use Generative AI?

No
