### PR TITLE
`WaitForTopics`: wait for publisher-subscriber connection to be established

### DIFF
--- a/launch_testing_ros/launch_testing_ros/wait_for_topics.py
+++ b/launch_testing_ros/launch_testing_ros/wait_for_topics.py
@@ -108,9 +108,9 @@ class WaitForTopics:
 
     def wait(self, *args, **kwargs):
         self.__ros_node.start_subscribers(self.topic_tuples)
+        self.__ros_node.any_publisher_connected.wait(self.timeout)        
         if self.trigger:
             self.trigger(self.__ros_node, *args, **kwargs)
-        self.__ros_node.any_publisher_connected.wait(self.timeout)
         return self.__ros_node.msg_event_object.wait(self.timeout)
 
     def shutdown(self):

--- a/launch_testing_ros/launch_testing_ros/wait_for_topics.py
+++ b/launch_testing_ros/launch_testing_ros/wait_for_topics.py
@@ -108,7 +108,7 @@ class WaitForTopics:
 
     def wait(self, *args, **kwargs):
         self.__ros_node.start_subscribers(self.topic_tuples)
-        self.__ros_node.any_publisher_connected.wait(self.timeout)        
+        self.__ros_node.any_publisher_connected.wait(self.timeout)
         if self.trigger:
             self.trigger(self.__ros_node, *args, **kwargs)
         return self.__ros_node.msg_event_object.wait(self.timeout)

--- a/launch_testing_ros/launch_testing_ros/wait_for_topics.py
+++ b/launch_testing_ros/launch_testing_ros/wait_for_topics.py
@@ -63,7 +63,7 @@ class WaitForTopics:
             topic_list = [('topic_1', String), ('topic_2', String)]
             wait_for_topics = WaitForTopics(topic_list, timeout=5.0, trigger=trigger_function)
             # The trigger function will be called inside the wait() method after the
-            # subscribers are created and before the publishers are connected.
+            # subscribers are created and the publishers are connected.
             assert wait_for_topics.wait("Hello World!")
             print('Given topics are receiving messages !')
             wait_for_topics.shutdown()


### PR DESCRIPTION
## Description

In the `WaitForTopics` class, wait for subscription to be connected to at least one publisher before calling the trigger function.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

This is a continuation of PR #356 