### PR TITLE
Expose composable_lifecycle_node in front-end

### DIFF
--- a/launch_ros/launch_ros/actions/composable_node_container.py
+++ b/launch_ros/launch_ros/actions/composable_node_container.py
@@ -26,6 +26,7 @@ from launch.some_substitutions_type import SomeSubstitutionsType
 
 from .node import Node
 
+from ..descriptions import ComposableLifecycleNode
 from ..descriptions import ComposableNode
 
 
@@ -62,12 +63,26 @@ class ComposableNodeContainer(Node):
 
         composable_nodes = entity.get_attr(
             'composable_node', data_type=List[Entity], optional=True)
-        if composable_nodes is not None:
+        composable_lifecycle_nodes = entity.get_attr(
+            'composable_lifecycle_node', data_type=List[Entity], optional=True)
+
+        if composable_lifecycle_nodes is not None or composable_nodes is not None:
             kwargs['composable_node_descriptions'] = []
+
+        if composable_nodes is not None:
             for entity in composable_nodes:
                 composable_node_cls, composable_node_kwargs = ComposableNode.parse(parser, entity)
                 kwargs['composable_node_descriptions'].append(
                     composable_node_cls(**composable_node_kwargs))
+                entity.assert_entity_completely_parsed()
+
+        if composable_lifecycle_nodes is not None:
+            for entity in composable_lifecycle_nodes:
+                composable_node_cls, composable_node_kwargs = ComposableLifecycleNode.parse(
+                    parser, entity)
+                kwargs['composable_node_descriptions'].append(
+                    composable_node_cls(**composable_node_kwargs))
+                entity.assert_entity_completely_parsed()
 
         return cls, kwargs
 

--- a/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
@@ -16,10 +16,15 @@
 
 from typing import List
 from typing import Optional
+from typing import Union
 
 import launch
+from launch.frontend import Entity
+from launch.frontend import Parser
+from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.substitution import Substitution
 from launch.utilities import perform_substitutions
+from launch.utilities import type_utils
 from launch_ros.parameters_type import Parameters
 from launch_ros.remap_rule_type import RemapRules
 from launch_ros.utilities import LifecycleEventManager
@@ -32,7 +37,7 @@ class ComposableLifecycleNode(ComposableNode):
 
     def __init__(
         self, *,
-        autostart: bool = False,
+        autostart: Union[bool, SomeSubstitutionsType] = False,
         **kwargs
     ) -> None:
         """
@@ -42,9 +47,20 @@ class ComposableLifecycleNode(ComposableNode):
         """
         super().__init__(**kwargs)
 
-        self.__autostart = autostart
+        self.__autostart = type_utils.normalize_typed_substitution(autostart, bool)
         self.__lifecycle_event_manager = None
         self.__node_name = super().node_name
+
+    @classmethod
+    def parse(cls, parser: Parser, entity: Entity):
+        """Parse composable_lifecycle_node."""
+        _, kwargs = super().parse(parser, entity)
+
+        autostart = entity.get_attr('autostart', data_type=bool, optional=True, can_be_str=True)
+        if autostart is not None:
+            kwargs['autostart'] = parser.parse_if_substitutions(autostart)
+
+        return cls, kwargs
 
     def init_lifecycle_event_manager(self, context: launch.LaunchContext) -> None:
         # LifecycleEventManager needs a pre-substitution node name
@@ -73,9 +89,9 @@ class ComposableLifecycleNode(ComposableNode):
         return super().node_namespace
 
     @property
-    def node_autostart(self):
+    def node_autostart(self) -> Union[bool, List[Substitution]]:
         """Getter for autostart."""
-        return self.__autostart
+        return self.__autostart  # type: Union[bool, List[Substitution]]
 
     @property
     def parameters(self) -> Optional[Parameters]:

--- a/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
@@ -14,6 +14,7 @@
 
 """Module for a description of a ComposableLifecycleNode."""
 
+from typing import cast
 from typing import List
 from typing import Optional
 from typing import Union
@@ -22,7 +23,9 @@ import launch
 from launch.frontend import Entity
 from launch.frontend import Parser
 from launch.some_substitutions_type import SomeSubstitutionsType
+from launch.some_substitutions_type import SomeSubstitutionsType_types_tuple
 from launch.substitution import Substitution
+from launch.utilities import ensure_argument_type
 from launch.utilities import perform_substitutions
 from launch.utilities import type_utils
 from launch_ros.parameters_type import Parameters
@@ -47,8 +50,17 @@ class ComposableLifecycleNode(ComposableNode):
         """
         super().__init__(**kwargs)
 
-        self.__autostart = type_utils.normalize_typed_substitution(autostart, bool)
-        self.__lifecycle_event_manager = None
+        ensure_argument_type(
+            autostart,
+            list(SomeSubstitutionsType_types_tuple) + [bool],
+            'autostart',
+            'ComposableLifecycleNode'
+        )
+        self.__autostart = cast(
+            Union[bool, List[Substitution]],
+            type_utils.normalize_typed_substitution(autostart, bool)
+        )
+        self.__lifecycle_event_manager = None  # type: Optional[LifecycleEventManager]
         self.__node_name = super().node_name
 
     @classmethod
@@ -91,7 +103,7 @@ class ComposableLifecycleNode(ComposableNode):
     @property
     def node_autostart(self) -> Union[bool, List[Substitution]]:
         """Getter for autostart."""
-        return self.__autostart  # type: Union[bool, List[Substitution]]
+        return self.__autostart
 
     @property
     def parameters(self) -> Optional[Parameters]:

--- a/launch_ros/launch_ros/descriptions/composable_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_node.py
@@ -138,8 +138,6 @@ class ComposableNode:
             for extra_arg in extra_arguments:
                 extra_arg.assert_entity_completely_parsed()
 
-        entity.assert_entity_completely_parsed()
-
         return cls, kwargs
 
     @property


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Expose `composable_lifecycle_node`s for use in `load_node_component` and `composable_node_container` from the front-end.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Fixes #478 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Yes, users can now auto start lifecycle node components from front-ends such as `launch_xml` and `launch_yaml`.

### Did you use Generative AI?
No
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
There are no front-end tests yet, since there are no example/demo lifecycle component nodes (no current lifecycle talker listener component).
So there is no 'simple' case to test.

While I was making some custom debugging node I ran into #479. 
<!--
If applicable, provide any additional context or details about the changes.
-->
