### PR TITLE
Make FindPackage substitutions a Path to get operator /

### DIFF
--- a/launch_ros/launch_ros/substitutions/find_package.py
+++ b/launch_ros/launch_ros/substitutions/find_package.py
@@ -25,11 +25,12 @@ from launch.frontend import expose_substitution
 from launch.launch_context import LaunchContext
 from launch.some_substitutions_type import SomeSubstitutionsType
 from launch.substitution import Substitution
+from launch.substitutions import PathSubstitution
 from launch.utilities import normalize_to_list_of_substitutions
 from launch.utilities import perform_substitutions
 
 
-class FindPackage(Substitution):
+class FindPackage(PathSubstitution):
     """
     Abstract base class for substitutions involving finding a package.
 
@@ -41,7 +42,7 @@ class FindPackage(Substitution):
         package: SomeSubstitutionsType,
     ) -> None:
         """Create a FindPackage substitution."""
-        super().__init__()
+        super().__init__(self)
         self.__package = normalize_to_list_of_substitutions(package)
 
     @classmethod

--- a/test_launch_ros/test/test_launch_ros/substitutions/test_find_package.py
+++ b/test_launch_ros/test/test_launch_ros/substitutions/test_find_package.py
@@ -36,3 +36,10 @@ def test_find_package_share():
     package_prefix = Path(sub.perform(context))
     package_xml_file = package_prefix / Path('package.xml')
     assert package_xml_file.is_file()
+
+
+def test_find_package_paths():
+    sub = FindPackageShare('launch_ros') / 'package.xml'
+    context = LaunchContext()
+    result_path = sub.perform(context)
+    assert Path(result_path).is_file()


### PR DESCRIPTION
## Description

Part of https://github.com/robograph-project/planning/issues/38
Depends on ros2/launch#914

Make `FindPackage{X}` substitutions a subclass of `PathSubstitution` to get the path join operator for free.

Lets you change:

```
PathSubstitution(FindPackageShare('my_pkg')) / 'launch' / 'my_launch.yaml'
# or
PathJoinSubstitution([FindPackageShare('my_pkg'), 'launch', 'my_launch.yaml'])
```

into

```
FindPackageShare('my_pkg') / 'launch' / 'my_launch.yaml'
```


### Is this user-facing behavior change?

New user-facing capability, does not affect existing behavior

### Did you use Generative AI?

no

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
