### PR TITLE
Compatiblity with 'Populate Transitions' ros2/rcl#1269

### DIFF
--- a/launch_ros/launch_ros/events/lifecycle/state_transition.py
+++ b/launch_ros/launch_ros/events/lifecycle/state_transition.py
@@ -15,6 +15,7 @@
 """Module for StateTransition event."""
 
 from typing import Text
+from typing import TYPE_CHECKING
 
 from launch.event import Event
 
@@ -23,6 +24,9 @@ import lifecycle_msgs.msg
 if False:
     # imports here would cause loops, but are only used as forward-references for type-checking
     from ...actions import LifecycleNode  # noqa: F401
+
+if TYPE_CHECKING:
+    import builtin_interfaces.msg
 
 
 class StateTransition(Event):
@@ -45,7 +49,7 @@ class StateTransition(Event):
         super().__init__()
         self.__action = action
         self.__msg = msg
-        self.__timestamp = msg.timestamp
+        self.__stamp = msg.stamp
         self.__transition = msg.transition.label
         self.__start_state = msg.start_state.label
         self.__goal_state = msg.goal_state.label
@@ -61,9 +65,9 @@ class StateTransition(Event):
         return self.__msg
 
     @property
-    def timestamp(self) -> int:
-        """Getter for timestamp."""
-        return self.__timestamp
+    def stamp(self) -> 'builtin_interfaces.msg.Time':
+        """Getter for stamp."""
+        return self.__stamp
 
     @property
     def transition(self) -> Text:


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Compatibility with ros2/rcl#1269 and ros2/rcl_interfaces#185

Updates the `StateTransition` event to reflect the changes made in the message.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Yes, the `timestamp` field of the `StateTransition` event has been replaced with `stamp` of type `builtin_interfaces.msg.Time` (instead of int).

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
Requires ros2/rcl_interfaces#185