### PR TITLE
Fix launch_ros_testing shutdown race in WaitForTopics

### DIFF
--- a/launch_testing_ros/launch_testing_ros/wait_for_topics.py
+++ b/launch_testing_ros/launch_testing_ros/wait_for_topics.py
@@ -97,7 +97,6 @@ class WaitForTopics:
         finally:
             self.__ros_executor.shutdown()
 
-
     def _prepare_ros_node(self):
         node_name = '_test_node_' + ''.join(
             random.choices(string.ascii_uppercase + string.digits, k=10)

--- a/launch_testing_ros/launch_testing_ros/wait_for_topics.py
+++ b/launch_testing_ros/launch_testing_ros/wait_for_topics.py
@@ -86,7 +86,7 @@ class WaitForTopics:
         self._prepare_ros_node()
 
         # Start spinning
-        self.__ros_spin_thread = Thread(target=self._spin_handle_external_shutdown)
+        self.__ros_spin_thread = Thread(target=self._spin_handle_external_shutdown, daemon=False)
         self.__ros_spin_thread.start()
 
     def _spin_handle_external_shutdown(self):
@@ -94,6 +94,9 @@ class WaitForTopics:
             self.__ros_executor.spin()
         except rclpy.executors.ExternalShutdownException:
             pass
+        finally:
+            self.__ros_executor.shutdown()
+
 
     def _prepare_ros_node(self):
         node_name = '_test_node_' + ''.join(
@@ -137,6 +140,7 @@ class WaitForTopics:
 
     def __enter__(self):
         if not self.wait():
+            self.shutdown()
             raise RuntimeError('Did not receive messages on these topics: ',
                                self.topics_not_received())
         return self

--- a/launch_testing_ros/test/examples/wait_for_topic_inject_trigger_test.py
+++ b/launch_testing_ros/test/examples/wait_for_topic_inject_trigger_test.py
@@ -59,14 +59,6 @@ def generate_test_description():
     return launch.LaunchDescription(description)
 
 
-# TODO: Test cases fail on Windows debug builds
-# https://github.com/ros2/launch_ros/issues/292
-if sys.platform.startswith('win'):
-    pytest.skip(
-            'CLI tests can block for a pathological amount of time on Windows.',
-            allow_module_level=True)
-
-
 class TestFixture(unittest.TestCase):
 
     def test_topics_successful(self):

--- a/launch_testing_ros/test/examples/wait_for_topic_launch_test.py
+++ b/launch_testing_ros/test/examples/wait_for_topic_launch_test.py
@@ -51,75 +51,73 @@ def generate_test_description():
     return launch.LaunchDescription(description), {'count': n}
 
 
-# TODO: Test cases fail on Windows debug builds
-# https://github.com/ros2/launch_ros/issues/292
-if os.name != 'nt':
-    class TestFixture(unittest.TestCase):
+class TestFixture(unittest.TestCase):
 
-        def test_topics_successful(self, count: int):
-            """All the supplied topics should be read successfully."""
-            topic_list = [('chatter_' + str(i), String) for i in range(count)]
-            expected_topics = {'chatter_' + str(i) for i in range(count)}
-            message_pattern = re.compile(r'Hello World: \d+')
+    def test_topics_successful(self, count: int):
+        """All the supplied topics should be read successfully."""
+        topic_list = [('chatter_' + str(i), String) for i in range(count)]
+        expected_topics = {'chatter_' + str(i) for i in range(count)}
+        message_pattern = re.compile(r'Hello World: \d+')
 
-            # Method 1 : Using the magic methods and 'with' keyword
-            with WaitForTopics(
-                topic_list, timeout=15.0, messages_received_buffer_length=10
-            ) as wait_for_node_object_1:
-                assert wait_for_node_object_1.topics_received() == expected_topics
-                assert wait_for_node_object_1.topics_not_received() == set()
-                for topic_name, _ in topic_list:
-                    assert len(wait_for_node_object_1.received_messages(topic_name)) >= 1
-                    message = wait_for_node_object_1.received_messages(topic_name).pop().data
-                    assert message_pattern.match(message)
-
-            # Multiple instances of WaitForNode() can be created safely as
-            # their internal nodes spin in separate contexts
-            # Method 2 : Manually calling wait() and shutdown()
-            wait_for_node_object_2 = WaitForTopics(topic_list, timeout=15.0)
-            assert wait_for_node_object_2.wait()
-            assert wait_for_node_object_2.topics_received() == expected_topics
-            assert wait_for_node_object_2.topics_not_received() == set()
+        # Method 1 : Using the magic methods and 'with' keyword
+        with WaitForTopics(
+            topic_list, timeout=15.0, messages_received_buffer_length=10
+        ) as wait_for_node_object_1:
+            assert wait_for_node_object_1.topics_received() == expected_topics
+            assert wait_for_node_object_1.topics_not_received() == set()
             for topic_name, _ in topic_list:
                 assert len(wait_for_node_object_1.received_messages(topic_name)) >= 1
-                message = wait_for_node_object_2.received_messages(topic_name).pop().data
+                message = wait_for_node_object_1.received_messages(topic_name).pop().data
                 assert message_pattern.match(message)
-            wait_for_node_object_2.shutdown()
 
-        def test_topics_unsuccessful(self, count: int):
-            """All topics should be read except for the 'invalid_topic'."""
-            topic_list = [('chatter_' + str(i), String) for i in range(count)]
-            # Add a topic that will never have anything published on it
-            topic_list.append(('invalid_topic', String))
-            expected_topics = {'chatter_' + str(i) for i in range(count)}
+        # Multiple instances of WaitForNode() can be created safely as
+        # their internal nodes spin in separate contexts
+        # Method 2 : Manually calling wait() and shutdown()
+        wait_for_node_object_2 = WaitForTopics(topic_list, timeout=15.0)
+        assert wait_for_node_object_2.wait()
+        assert wait_for_node_object_2.topics_received() == expected_topics
+        assert wait_for_node_object_2.topics_not_received() == set()
+        for topic_name, _ in topic_list:
+            assert len(wait_for_node_object_1.received_messages(topic_name)) >= 1
+            message = wait_for_node_object_2.received_messages(topic_name).pop().data
+            assert message_pattern.match(message)
+        wait_for_node_object_2.shutdown()
 
-            # Method 1
-            with pytest.raises(RuntimeError):
-                with WaitForTopics(topic_list, timeout=2.0):
-                    pass
+    def test_topics_unsuccessful(self, count: int):
+        """All topics should be read except for the 'invalid_topic'."""
+        topic_list = [('chatter_' + str(i), String) for i in range(count)]
+        # Add a topic that will never have anything published on it
+        topic_list.append(('invalid_topic', String))
+        expected_topics = {'chatter_' + str(i) for i in range(count)}
 
-            # Method 2
-            wait_for_node_object = WaitForTopics(topic_list, timeout=2.0)
-            assert not wait_for_node_object.wait()
-            assert wait_for_node_object.topics_received() == expected_topics
-            assert wait_for_node_object.topics_not_received() == {'invalid_topic'}
-            wait_for_node_object.shutdown()
+        # Method 1
+        with pytest.raises(RuntimeError):
+            with WaitForTopics(topic_list, timeout=2.0):
+                pass
 
-        def test_trigger_function(self, count):
-            topic_list = [('chatter_' + str(i), String) for i in range(count)]
-            expected_topics = {'chatter_' + str(i) for i in range(count)}
+        # Method 2
+        wait_for_node_object = WaitForTopics(topic_list, timeout=2.0)
+        assert not wait_for_node_object.wait()
+        assert wait_for_node_object.topics_received() == expected_topics
+        assert wait_for_node_object.topics_not_received() == {'invalid_topic'}
+        wait_for_node_object.shutdown()
 
-            # Method 3 : Using a trigger function
+    def test_trigger_function(self, count):
+        topic_list = [('chatter_' + str(i), String) for i in range(count)]
+        expected_topics = {'chatter_' + str(i) for i in range(count)}
 
-            # Using a list to store the trigger function's argument as it is mutable
-            is_trigger_called = [False]
+        # Method 3 : Using a trigger function
 
-            def trigger_function(node, arg):
-                node.get_logger().info(f'Trigger function called with argument: {arg[0]}')
-                arg[0] = True
+        # Using a list to store the trigger function's argument as it is mutable
+        is_trigger_called = [False]
 
-            wait_for_node_object = WaitForTopics(topic_list, timeout=2.0, trigger=trigger_function)
-            assert wait_for_node_object.wait(is_trigger_called)
-            assert wait_for_node_object.topics_received() == expected_topics
-            assert wait_for_node_object.topics_not_received() == set()
-            assert is_trigger_called[0]
+        def trigger_function(node, arg):
+            node.get_logger().info(f'Trigger function called with argument: {arg[0]}')
+            arg[0] = True
+
+        wait_for_node_object = WaitForTopics(topic_list, timeout=2.0, trigger=trigger_function)
+        assert wait_for_node_object.wait(is_trigger_called)
+        assert wait_for_node_object.topics_received() == expected_topics
+        assert wait_for_node_object.topics_not_received() == set()
+        assert is_trigger_called[0]
+        wait_for_node_object.shutdown()


### PR DESCRIPTION
* Change thread type daemon=False to follow some best practice from the pybind11 community: https://github.com/pybind/pybind11/issues/3274
* Fix WaitForTopics context manager to appropriately clean up after itself in the case that topics aren't available
* Shutdown WaitForTopics in another test cas