### PR TITLE
Set PYTHONUNBUFFERED to 1 to avoid hangs due to lost buffers

### DIFF
--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -54,6 +54,7 @@ class TestNode(unittest.TestCase):
             exec_name='my_node_process',
             ros_arguments=ros_arguments,
             arguments=['--number_of_cycles', '1'],
+            additional_env={'PYTHONUNBUFFERED': '1'},
             parameters=parameters,
             remappings=remappings,
         )
@@ -106,6 +107,7 @@ class TestNode(unittest.TestCase):
         long_running_node = launch_ros.actions.Node(
             package='demo_nodes_py', executable='talker_qos', output='screen',
             namespace='my_ns',
+            additional_env={'PYTHONUNBUFFERED': '1'},
         )
 
         # This node will exit after publishing a single message. It is required, so we
@@ -115,6 +117,7 @@ class TestNode(unittest.TestCase):
         required_node = launch_ros.actions.Node(
             package='demo_nodes_py', executable='talker_qos', output='screen',
             namespace='my_ns2', arguments=['--number_of_cycles', '1'],
+            additional_env={'PYTHONUNBUFFERED': '1'},
             on_exit=Shutdown()
         )
 
@@ -255,6 +258,7 @@ class TestNode(unittest.TestCase):
             package='demo_nodes_py', executable='talker_qos', output='screen',
             arguments=['--number_of_cycles', '1'],
             parameters=[{'my_param': 'value'}],
+            additional_env={'PYTHONUNBUFFERED': '1'},
         )
         self._assert_launch_no_errors([node_action])
 
@@ -325,6 +329,7 @@ def get_test_node_name_parameters():
                 package='asd',
                 executable='bsd',
                 name='my_node',
+                additional_env={'PYTHONUNBUFFERED': '1'},
             ),
             False,
             id='Node without namespace'
@@ -334,6 +339,7 @@ def get_test_node_name_parameters():
                 package='asd',
                 executable='bsd',
                 namespace='my_ns',
+                additional_env={'PYTHONUNBUFFERED': '1'},
             ),
             False,
             id='Node without name'
@@ -344,6 +350,7 @@ def get_test_node_name_parameters():
                 executable='bsd',
                 name='my_node',
                 namespace='my_ns',
+                additional_env={'PYTHONUNBUFFERED': '1'},
             ),
             True,
             id='Node with fully qualified name'


### PR DESCRIPTION

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->



This attempts to fix https://github.com/ros2/launch_ros/issues/444 by forcing stdout to not buffer and hang due to that buffer being lost during high resource usage.
It's the same behavior already being used in `launch_testing_ros` tests: 
https://github.com/ros2/launch_ros/blob/a9f22f9d09e8800d8a8ccc37e3ff060f95249bc2/launch_testing_ros/test/examples/set_param_launch_test.py#L35-L43


Fixes #444 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
No
### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
I've been testing setting this variable on windows 2025 CI with parallel test execution since the win-2025 nightlies have been suffering from this quite often. So far I could not reproduce the hang behavior with this variable set. 

Change https://github.com/ros2/ci/commit/877b395f8611b2ba55ec418f7b45abe67916a01c and test run [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows-2025&build=24)](https://ci.ros2.org/job/ci_windows-2025/24/).