### PR TITLE
Add per composable node log_level support

### DIFF
--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -40,6 +40,7 @@ from launch.utilities import type_utils
 from launch_ros.parameter_descriptions import ParameterFile
 
 import lifecycle_msgs.msg
+import rclpy.logging
 
 from .composable_node_container import ComposableNodeContainer
 from .lifecycle_transition import LifecycleTransition
@@ -321,7 +322,6 @@ def get_composable_node_load_request(
     combined_ns = make_namespace_absolute(prefix_namespace(base_ns, expanded_ns))
     if combined_ns is not None:
         request.node_namespace = combined_ns
-    # request.log_level = perform_substitutions(context, node_description.log_level)
     remappings = []
     global_remaps = context.launch_configurations.get('ros_remaps', None)
     if global_remaps:
@@ -366,4 +366,18 @@ def get_composable_node_load_request(
                 )
             )
         ]
+
+    if composable_node_description.log_level is not None:
+        log_level_str = perform_substitutions(
+            context, composable_node_description.log_level)
+        try:
+            request.log_level = int(
+                rclpy.logging.get_logging_severity_from_string(log_level_str))
+        except Exception:
+            raise RuntimeError(
+                f"Invalid log_level '{log_level_str}' for node "
+                f"'{request.node_name}'. Valid values are: "
+                "DEBUG, INFO, WARN, ERROR, FATAL (case-insensitive)."
+            )
+
     return request

--- a/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
@@ -119,3 +119,8 @@ class ComposableLifecycleNode(ComposableNode):
     def extra_arguments(self) -> Optional[Parameters]:
         """Get container extra arguments YAML files or dicts with substitutions to be performed."""
         return super().extra_arguments
+
+    @property
+    def log_level(self) -> Optional[List[Substitution]]:
+        """Get log level as a sequence of substitutions to be performed."""
+        return super().log_level

--- a/launch_ros/launch_ros/descriptions/composable_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_node.py
@@ -45,6 +45,7 @@ class ComposableNode:
         remappings: Optional[SomeRemapRules] = None,
         extra_arguments: Optional[SomeParameters] = None,
         condition: Optional[Condition] = None,
+        log_level: Optional[SomeSubstitutionsType] = None,
     ) -> None:
         """
         Initialize a ComposableNode description.
@@ -57,6 +58,7 @@ class ComposableNode:
         :param remappings: list of from/to pairs for remapping names
         :param extra_arguments: container specific arguments to be passed to the loaded node
         :param condition: action will be executed if the condition evaluates to true
+        :param log_level: log level for the node (e.g. 'debug', 'info', 'warn', 'error', 'fatal')
         """
         self.__package = normalize_to_list_of_substitutions(package)
         self.__node_plugin = normalize_to_list_of_substitutions(plugin)
@@ -82,6 +84,10 @@ class ComposableNode:
             self.__extra_arguments = normalize_parameters(extra_arguments)
 
         self.__condition = condition
+
+        self.__log_level = None  # type: Optional[List[Substitution]]
+        if log_level is not None:
+            self.__log_level = normalize_to_list_of_substitutions(log_level)
 
     @classmethod
     def parse(cls, parser: Parser, entity: Entity):
@@ -138,6 +144,10 @@ class ComposableNode:
             for extra_arg in extra_arguments:
                 extra_arg.assert_entity_completely_parsed()
 
+        log_level = entity.get_attr('log_level', optional=True)
+        if log_level is not None:
+            kwargs['log_level'] = parser.parse_substitution(log_level)
+
         return cls, kwargs
 
     @property
@@ -178,3 +188,8 @@ class ComposableNode:
     def condition(self) -> Optional[Condition]:
         """Getter for condition."""
         return self.__condition
+
+    @property
+    def log_level(self) -> Optional[List[Substitution]]:
+        """Get log level as a sequence of substitutions to be performed."""
+        return self.__log_level

--- a/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
@@ -36,6 +36,7 @@ from rcl_interfaces.msg import ParameterType
 import rclpy
 import rclpy.context
 import rclpy.executors
+import rclpy.logging
 import rclpy.node
 
 TEST_CONTAINER_NAME = 'mock_component_container'
@@ -84,6 +85,7 @@ def _load_composable_node(
     condition=None,
     parameters=None,
     remappings=None,
+    log_level=None,
     target_container=f'/{TEST_CONTAINER_NAME}'
 ):
     return LoadComposableNodes(
@@ -97,6 +99,7 @@ def _load_composable_node(
                 namespace=namespace,
                 parameters=parameters,
                 remappings=remappings,
+                log_level=log_level,
             )
         ])
 
@@ -654,3 +657,59 @@ def test_load_node_with_condition_in_group(mock_component_container):
     assert len(request.remap_rules) == 0
     assert len(request.parameters) == 0
     assert len(request.extra_arguments) == 0
+
+
+def test_load_node_without_log_level(mock_component_container):
+    """Test that log_level defaults to 0 (UNSET) when not specified."""
+    _assert_launch_no_errors([
+        _load_composable_node(
+            package='foo_package',
+            plugin='bar_plugin',
+            name='test_node_name',
+        )
+    ])
+
+    assert len(mock_component_container.requests) == 1
+    request = mock_component_container.requests[0]
+    assert request.log_level == 0
+
+
+@pytest.mark.parametrize('log_level_str,expected', [
+    ('DEBUG', rclpy.logging.LoggingSeverity.DEBUG),
+    ('debug', rclpy.logging.LoggingSeverity.DEBUG),
+    ('INFO', rclpy.logging.LoggingSeverity.INFO),
+    ('info', rclpy.logging.LoggingSeverity.INFO),
+    ('WARN', rclpy.logging.LoggingSeverity.WARN),
+    ('warn', rclpy.logging.LoggingSeverity.WARN),
+    ('ERROR', rclpy.logging.LoggingSeverity.ERROR),
+    ('error', rclpy.logging.LoggingSeverity.ERROR),
+    ('FATAL', rclpy.logging.LoggingSeverity.FATAL),
+    ('fatal', rclpy.logging.LoggingSeverity.FATAL),
+])
+def test_load_node_with_log_level(mock_component_container, log_level_str, expected):
+    """Test that log_level is correctly mapped for all valid values."""
+    _assert_launch_no_errors([
+        _load_composable_node(
+            package='foo_package',
+            plugin='bar_plugin',
+            name='test_node_name',
+            log_level=log_level_str,
+        )
+    ])
+
+    assert len(mock_component_container.requests) == 1
+    request = mock_component_container.requests[0]
+    assert request.log_level == int(expected)
+
+
+def test_load_node_with_invalid_log_level(mock_component_container):
+    """Test that an invalid log_level raises an exception."""
+    with pytest.raises(RuntimeError):
+        _assert_launch_no_errors([
+            _load_composable_node(
+                package='foo_package',
+                plugin='bar_plugin',
+                name='test_node_name',
+                log_level='INVALID_LEVEL',
+            )
+        ])


### PR DESCRIPTION
## Description

Fixes # (https://github.com/ros2/rclcpp/issues/3091)

### Is this user-facing behavior change?

No, this change add new parameter for `ComposableNode`, not affect the existing functions.

### Did you use Generative AI?

Yes, partially with Claude Sonnet 4.6.

### Additional Information

Example for per component log level feature enabled:

```python
def generate_launch_description():
    return LaunchDescription([ComposableNodeContainer(
        name='component_demo_container',
        namespace='',
        package='rclcpp_components',
        executable='component_container',
        composable_node_descriptions=[
            ComposableNode(
                package='<PKG>',
                plugin='<PLUGIN>',
                log_level='DEBUG',  # component log level
            ),
        ],
        arguments=['--ros-args', '--log-level', 'INFO'],  # container log level
    )])
```

Related PR: https://github.com/ros2/rclcpp/pull/3092, https://github.com/ros2/ros2cli/pull/1212
