### PR TITLE
Fix Pytest 8/9 compatibility in launch_testing_ros hooks

### DIFF
--- a/launch_testing_ros/launch_testing_ros_pytest_entrypoint.py
+++ b/launch_testing_ros/launch_testing_ros_pytest_entrypoint.py
@@ -20,11 +20,20 @@
 import pytest
 
 
-def pytest_launch_collect_makemodule(path, parent, entrypoint):
+def _pytest_version_ge(major, minor=0, patch=0):
+    """Return True if pytest version is >= the given version."""
+    pytest_version = tuple([int(v) for v in pytest.__version__.split('.')])
+    return pytest_version >= (major, minor, patch)
+
+
+def pytest_launch_collect_makemodule(module_path, parent, entrypoint):
     marks = getattr(entrypoint, 'pytestmark', [])
     if marks and any(m.name == 'rostest' for m in marks):
         from launch_testing_ros.pytest.hooks import LaunchROSTestModule
-        module = LaunchROSTestModule.from_parent(parent=parent, fspath=path)
+        if _pytest_version_ge(7):
+            module = LaunchROSTestModule.from_parent(parent=parent, path=module_path)
+        else:
+            module = LaunchROSTestModule.from_parent(parent=parent, fspath=module_path)
         for mark in marks:
             decorator = getattr(pytest.mark, mark.name)
             decorator = decorator.with_args(*mark.args, **mark.kwargs)


### PR DESCRIPTION
This PR fixes deprecated hook signatures in launch_testing_ros that cause failures in newer pytest versions (e.g. Pytest 9.0).

Related: https://github.com/ros2/launch/pull/972