### PR TITLE
Fix unsafe shutdown pattern in test_launch_ros

### DIFF
--- a/test_launch_ros/test/test_launch_ros/actions/test_composable_node_container.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_composable_node_container.py
@@ -43,7 +43,7 @@ def _assert_launch_no_errors(actions, *, timeout_sec=5):
     loop.run_until_complete(asyncio.sleep(timeout_sec))
     if not launch_task.done():
         loop.create_task(ls.shutdown())
-        loop.run_until_complete(launch_task)
+    loop.run_until_complete(launch_task)
     assert 0 == launch_task.result()
     return ls.context
 

--- a/test_launch_ros/test/test_launch_ros/frontend/test_component_container.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_component_container.py
@@ -188,7 +188,7 @@ def test_launch_container_executor_modes(file_factory, container_args):
         loop.run_until_complete(asyncio.sleep(5))
         if not launch_task.done():
             loop.create_task(ls.shutdown())
-            loop.run_until_complete(launch_task)
+        loop.run_until_complete(launch_task)
         assert 0 == launch_task.result()
 
 
@@ -252,5 +252,5 @@ def check_launch_component_container(file):
     loop.run_until_complete(asyncio.sleep(timeout_sec))
     if not launch_task.done():
         loop.create_task(ls.shutdown())
-        loop.run_until_complete(launch_task)
+    loop.run_until_complete(launch_task)
     assert 0 == launch_task.result()

--- a/test_launch_ros/test/test_launch_ros/frontend/test_lifecycle_node_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_lifecycle_node_frontend.py
@@ -153,7 +153,7 @@ def check_launch_lifecycle_node(file):
     loop.run_until_complete(asyncio.sleep(timeout_sec))
     if not launch_task.done():
         loop.create_task(ls.shutdown())
-        loop.run_until_complete(launch_task)
+    loop.run_until_complete(launch_task)
     assert 0 == launch_task.result()
 
     talker_node_cmd_string = ' '.join(lc_talker_node.process_details['cmd'])

--- a/test_launch_ros/test/test_launch_ros/utilities/test_track_node_names.py
+++ b/test_launch_ros/test/test_launch_ros/utilities/test_track_node_names.py
@@ -51,7 +51,7 @@ def _launch(launch_description):
     loop.run_until_complete(asyncio.sleep(5))
     if not launch_task.done():
         loop.create_task(ls.shutdown())
-        loop.run_until_complete(launch_task)
+    loop.run_until_complete(launch_task)
     return ls.context
 
 


### PR DESCRIPTION
## Description
Ensure loop always waits for `launch_task` to complete, even if it finished early. This prevents background `ROSAdapter` threads from accessing destroyed context/nodes, which causes intermittent segfaults (Access Violation 0xC0000005) on Windows.

### The Problem
Several tests in `test_launch_ros` were skipping the `ls.shutdown()` call if the `launch_task` had already completed. However, even if the task is done, the `LaunchService` may still have active resources, specifically the background thread started by `ROSAdapter`. When `ls.shutdown()` is skipped, the `LaunchService` and its `LaunchContext` are garbage collected as the test finishes, while the background thread continues spinning. When it eventually attempts to access the now-destroyed `rclpy.Context` or `Node` (e.g. during a `wait_set` operation), it triggers a segfault.

Fixes https://github.com/ros2/launch_ros/issues/539

### Reference
Failed build example: https://ci.ros2.org/job/nightly_win_rel/3788/
Traceback:
```
Windows fatal exception: access violation

Thread 0x00001110 (most recent call first):
  File "C:\ci\ws\install\Lib\site-packages\rclpy\executors.py", line 872 in _wait_for_ready_callbacks
  File "C:\ci\ws\install\Lib\site-packages\rclpy\executors.py", line 970 in wait_for_ready_callbacks
  File "C:\ci\ws\install\Lib\site-packages\rclpy\executors.py", line 1000 in _spin_once_impl
  File "C:\ci\ws\install\Lib\site-packages\rclpy\executors.py", line 1020 in spin_once
  File "C:\ci\ws\install\Lib\site-packages\launch_ros\ros_adapters.py", line 77 in _run
```



Assisted-by: Gemini CLI:2.0-Flash