### PR TITLE
Fix launch_testing_ros so it works with pytest 7.

### DIFF
--- a/launch_testing_ros/launch_testing_ros_pytest_entrypoint.py
+++ b/launch_testing_ros/launch_testing_ros_pytest_entrypoint.py
@@ -17,6 +17,8 @@
 # importing downstream modules in upstream packages when built with a merged
 # workspace.
 
+import pathlib
+
 import pytest
 
 
@@ -31,7 +33,8 @@ def pytest_launch_collect_makemodule(module_path, parent, entrypoint):
     if marks and any(m.name == 'rostest' for m in marks):
         from launch_testing_ros.pytest.hooks import LaunchROSTestModule
         if _pytest_version_ge(7):
-            module = LaunchROSTestModule.from_parent(parent=parent, path=module_path)
+            path = pathlib.Path(module_path)
+            module = LaunchROSTestModule.from_parent(parent=parent, path=path)
         else:
             module = LaunchROSTestModule.from_parent(parent=parent, fspath=module_path)
         for mark in marks:

--- a/launch_testing_ros/test/examples/check_msgs_launch_test.py
+++ b/launch_testing_ros/test/examples/check_msgs_launch_test.py
@@ -55,11 +55,8 @@ class TestFixture(unittest.TestCase):
         self.msg_event_object.set()
 
     def spin(self):
-        try:
-            while rclpy.ok() and not self.spinning.is_set():
-                rclpy.spin_once(self.node, timeout_sec=0.1)
-        finally:
-            return
+        while rclpy.ok() and not self.spinning.is_set():
+            rclpy.spin_once(self.node, timeout_sec=0.1)
 
     def setUp(self):
         rclpy.init()


### PR DESCRIPTION
## Description

We need this compatibility because Windows pixi is still using an older pytest.  This doesn't really
hurt anything either.

While we are in here, fix a pep257 warning that I noticed in the tests.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

Yes, Claude Opus 4.7

### Additional Information

This is follow-up to https://github.com/ros2/launch_ros/pull/540

This needs to be backported to Lyrical along with #541 