### PR TITLE
Fix launch_testing_ros compatibility with legacy hook specs

### DIFF
--- a/launch_testing_ros/launch_testing_ros_pytest_entrypoint.py
+++ b/launch_testing_ros/launch_testing_ros_pytest_entrypoint.py
@@ -28,15 +28,15 @@ def _pytest_version_ge(major, minor=0, patch=0):
     return pytest_version >= (major, minor, patch)
 
 
-def pytest_launch_collect_makemodule(module_path, parent, entrypoint):
+def pytest_launch_collect_makemodule(path, parent, entrypoint):
     marks = getattr(entrypoint, 'pytestmark', [])
     if marks and any(m.name == 'rostest' for m in marks):
         from launch_testing_ros.pytest.hooks import LaunchROSTestModule
         if _pytest_version_ge(7):
-            path = pathlib.Path(module_path)
+            path = pathlib.Path(path)
             module = LaunchROSTestModule.from_parent(parent=parent, path=path)
         else:
-            module = LaunchROSTestModule.from_parent(parent=parent, fspath=module_path)
+            module = LaunchROSTestModule.from_parent(parent=parent, fspath=path)
         for mark in marks:
             decorator = getattr(pytest.mark, mark.name)
             decorator = decorator.with_args(*mark.args, **mark.kwargs)

--- a/launch_testing_ros/test/test_pytest_entrypoint.py
+++ b/launch_testing_ros/test/test_pytest_entrypoint.py
@@ -1,0 +1,40 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import launch_testing_ros_pytest_entrypoint
+
+
+class LegacyLaunchTestingHooks:
+
+    @pytest.hookspec(firstresult=True)
+    def pytest_launch_collect_makemodule(path, parent, entrypoint):
+        pass
+
+
+class CurrentLaunchTestingHooks:
+
+    @pytest.hookspec(firstresult=True)
+    def pytest_launch_collect_makemodule(module_path, path, parent, entrypoint):
+        pass
+
+
+@pytest.mark.parametrize(
+    'hookspecs', [LegacyLaunchTestingHooks, CurrentLaunchTestingHooks]
+)
+def test_pytest_entrypoint_hook_compatibility(hookspecs):
+    manager = pytest.PytestPluginManager()
+    manager.add_hookspecs(hookspecs)
+    manager.register(launch_testing_ros_pytest_entrypoint, 'launch_ros')

--- a/launch_testing_ros/test/test_pytest_entrypoint.py
+++ b/launch_testing_ros/test/test_pytest_entrypoint.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 import launch_testing_ros_pytest_entrypoint
+import pytest
 
 
 class LegacyLaunchTestingHooks:


### PR DESCRIPTION
## Description

`launch_testing` now keeps both `module_path` and `path` in its current hook specification, while older released versions only expose `path`. `launch_ros` 0.29.9 declares only `module_path`, so Pluggy rejects the plugin when those package versions are mixed.

Use the `path` argument shared by both released hook specifications and add focused registration tests for the legacy and current shapes.

Addresses #550. This should be backported to Lyrical after merging in Rolling.

### Is this user-facing behavior change?

Yes. Launch tests can be collected when a newer `launch_testing_ros` is used with an older path-only `launch_testing` release, instead of failing during pytest plugin registration.

### Did you use Generative AI?

Yes. OpenAI Codex (GPT-5) assisted with root-cause analysis and preparing the focused code and tests. I reviewed the diff and test results.

### Additional Information

Local verification:
- pytest 7.4.4: 2 tests passed
- pytest 9.1.1: 2 tests passed
- legacy and current hookspec invocation probes passed on pytest 7.4.4 and 9.1.1, including path and marker forwarding
- `ament_flake8`, `ament_pep257`, and `ament_copyright` on both changed Python files
- Python bytecode compilation
- `git diff --check`