### PR TITLE
Allow SetUseSimTime to disable simulated time

### DIFF
--- a/launch_ros/launch_ros/actions/set_use_sim_time.py
+++ b/launch_ros/launch_ros/actions/set_use_sim_time.py
@@ -65,5 +65,5 @@ class SetUseSimTime(Action):
             value,
         )
         node.set_parameters([param])
-        if not node.get_parameter('use_sim_time').get_parameter_value().bool_value:
+        if node.get_parameter('use_sim_time').get_parameter_value().bool_value != value:
             raise RuntimeError('Failed to set use_sim_time parameter')

--- a/test_launch_ros/test/test_launch_ros/frontend/test_set_use_sim_timer_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_set_use_sim_timer_frontend.py
@@ -44,14 +44,34 @@ xml_file = textwrap.dedent(
 )
 
 
+yaml_false_file = textwrap.dedent(
+    r"""
+    launch:
+        - set_use_sim_time:
+            value: false
+    """
+)
+
+
+xml_false_file = textwrap.dedent(
+    r"""
+    <launch>
+        <set_use_sim_time value="false" />
+    </launch>
+    """
+)
+
+
 @pytest.mark.parametrize(
-    'file',
+    'file, expected_value',
     [
-        pytest.param(yaml_file, id='YAML'),
-        pytest.param(xml_file, id='XML'),
+        pytest.param(yaml_file, True, id='YAML-true'),
+        pytest.param(xml_file, True, id='XML-true'),
+        pytest.param(yaml_false_file, False, id='YAML-false'),
+        pytest.param(xml_false_file, False, id='XML-false'),
     ],
 )
-def test_set_use_sim_timer(file):
+def test_set_use_sim_timer(file, expected_value):
     root_entity, parser = Parser.load(io.StringIO(file))
     ld = parser.parse_description(root_entity)
     ls = LaunchService()
@@ -59,6 +79,5 @@ def test_set_use_sim_timer(file):
     assert 0 == ls.run()
 
     lc = ls.context
-    assert len(ld.entities) == 2
-    assert isinstance(ld.entities[1], SetUseSimTime)
-    assert perform_typed_substitution(lc, ld.entities[1].value, bool) is True
+    assert isinstance(ld.entities[-1], SetUseSimTime)
+    assert perform_typed_substitution(lc, ld.entities[-1].value, bool) is expected_value


### PR DESCRIPTION
## Summary
- compare the resulting `use_sim_time` value with the requested boolean instead of requiring it to be `true`
- preserve the existing failure path when the resulting value does not match the request
- extend the XML and YAML frontend test with native `false` values while retaining true substitution coverage

## Testing
- reproduced the current `RuntimeError` after `SetUseSimTime(False)` had already set the parameter to false
- passed XML/YAML true and false parser-to-action execution probes using the real launch frontends and a fake node at the unavailable rclpy boundary
- `ament_flake8` on both changed files
- `ament_pep257` on both changed files
- `ament_copyright` on both changed files
- `python -m py_compile` on both changed files
- `git diff --check`

The repository-native frontend test was not run locally because this Windows environment does not have a compiled `rclpy` extension.