### PR TITLE
Allow unnamed composable nodes in XML and YAML frontends

### DIFF
--- a/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
@@ -68,12 +68,12 @@ class ComposableLifecycleNode(ComposableNode):
         """Parse composable_lifecycle_node."""
         _, kwargs = super().parse(parser, entity)
 
-        if 'name' not in kwargs:
-            raise ValueError('Composable lifecycle nodes require a name')
-
         autostart = entity.get_attr('autostart', data_type=bool, optional=True, can_be_str=True)
         if autostart is not None:
             kwargs['autostart'] = parser.parse_if_substitutions(autostart)
+
+        if 'name' not in kwargs and autostart is not None and autostart is not False:
+            raise ValueError('Composable lifecycle nodes with autostart require a name')
 
         return cls, kwargs
 

--- a/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_lifecycle_node.py
@@ -68,6 +68,9 @@ class ComposableLifecycleNode(ComposableNode):
         """Parse composable_lifecycle_node."""
         _, kwargs = super().parse(parser, entity)
 
+        if 'name' not in kwargs:
+            raise ValueError('Composable lifecycle nodes require a name')
+
         autostart = entity.get_attr('autostart', data_type=bool, optional=True, can_be_str=True)
         if autostart is not None:
             kwargs['autostart'] = parser.parse_if_substitutions(autostart)

--- a/launch_ros/launch_ros/descriptions/composable_node.py
+++ b/launch_ros/launch_ros/descriptions/composable_node.py
@@ -91,7 +91,9 @@ class ComposableNode:
 
         kwargs['package'] = parser.parse_substitution(entity.get_attr('pkg'))
         kwargs['plugin'] = parser.parse_substitution(entity.get_attr('plugin'))
-        kwargs['name'] = parser.parse_substitution(entity.get_attr('name'))
+        name = entity.get_attr('name', optional=True)
+        if name is not None:
+            kwargs['name'] = parser.parse_substitution(name)
 
         if_cond = entity.get_attr('if', optional=True)
         unless_cond = entity.get_attr('unless', optional=True)

--- a/test_launch_ros/test/test_launch_ros/frontend/test_component_container.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_component_container.py
@@ -20,6 +20,7 @@ import textwrap
 from launch import LaunchService
 from launch.frontend import Parser
 from launch.utilities import perform_substitutions
+from launch_ros.descriptions import ComposableLifecycleNode
 from launch_ros.descriptions import ComposableNode
 from launch_ros.utilities import evaluate_parameters
 import osrf_pycommon.process_utils
@@ -158,6 +159,52 @@ def test_composable_node_name_is_optional(file):
                         composable_lifecycle_node:
                             - pkg: composition
                               plugin: composition::Talker
+                """
+            ),
+            id='YAML',
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """
+                <launch>
+                    <node_container pkg="rclcpp_components" exec="component_container"
+                                    name="my_container" namespace="">
+                        <composable_lifecycle_node pkg="composition"
+                                                   plugin="composition::Talker" />
+                    </node_container>
+                </launch>
+                """
+            ),
+            id='XML',
+        ),
+    ],
+)
+def test_composable_lifecycle_node_name_is_optional_without_autostart(file):
+    root_entity, parser = Parser.load(io.StringIO(file))
+    launch_description = parser.parse_description(root_entity)
+    container = launch_description.describe_sub_entities()[0]
+    composable_node = container._ComposableNodeContainer__composable_node_descriptions[0]
+
+    assert isinstance(composable_node, ComposableLifecycleNode)
+    assert composable_node.node_name is None
+    assert composable_node.node_autostart is False
+
+
+@pytest.mark.parametrize(
+    'file',
+    [
+        pytest.param(
+            textwrap.dedent(
+                """
+                launch:
+                    - node_container:
+                        pkg: rclcpp_components
+                        exec: component_container
+                        name: my_container
+                        namespace: ''
+                        composable_lifecycle_node:
+                            - pkg: composition
+                              plugin: composition::Talker
                               autostart: true
                 """
             ),
@@ -182,7 +229,9 @@ def test_composable_node_name_is_optional(file):
 )
 def test_composable_lifecycle_node_name_is_required(file):
     root_entity, parser = Parser.load(io.StringIO(file))
-    with pytest.raises(ValueError, match='Composable lifecycle nodes require a name'):
+    with pytest.raises(
+        ValueError, match='Composable lifecycle nodes with autostart require a name'
+    ):
         parser.parse_description(root_entity)
 
 

--- a/test_launch_ros/test/test_launch_ros/frontend/test_component_container.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_component_container.py
@@ -20,6 +20,7 @@ import textwrap
 from launch import LaunchService
 from launch.frontend import Parser
 from launch.utilities import perform_substitutions
+from launch_ros.descriptions import ComposableNode
 from launch_ros.utilities import evaluate_parameters
 import osrf_pycommon.process_utils
 import pytest
@@ -96,6 +97,93 @@ def test_launch_component_container_xml():
     )
     with io.StringIO(xml_file) as f:
         check_launch_component_container(f)
+
+
+@pytest.mark.parametrize(
+    'file',
+    [
+        pytest.param(
+            textwrap.dedent(
+                """
+                launch:
+                    - node_container:
+                        pkg: rclcpp_components
+                        exec: component_container
+                        name: my_container
+                        namespace: ''
+                        composable_node:
+                            - pkg: composition
+                              plugin: composition::Talker
+                """
+            ),
+            id='YAML',
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """
+                <launch>
+                    <node_container pkg="rclcpp_components" exec="component_container"
+                                    name="my_container" namespace="">
+                        <composable_node pkg="composition" plugin="composition::Talker" />
+                    </node_container>
+                </launch>
+                """
+            ),
+            id='XML',
+        ),
+    ],
+)
+def test_composable_node_name_is_optional(file):
+    root_entity, parser = Parser.load(io.StringIO(file))
+    launch_description = parser.parse_description(root_entity)
+    container = launch_description.describe_sub_entities()[0]
+    composable_node = container._ComposableNodeContainer__composable_node_descriptions[0]
+
+    assert isinstance(composable_node, ComposableNode)
+    assert composable_node.node_name is None
+
+
+@pytest.mark.parametrize(
+    'file',
+    [
+        pytest.param(
+            textwrap.dedent(
+                """
+                launch:
+                    - node_container:
+                        pkg: rclcpp_components
+                        exec: component_container
+                        name: my_container
+                        namespace: ''
+                        composable_lifecycle_node:
+                            - pkg: composition
+                              plugin: composition::Talker
+                              autostart: true
+                """
+            ),
+            id='YAML',
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """
+                <launch>
+                    <node_container pkg="rclcpp_components" exec="component_container"
+                                    name="my_container" namespace="">
+                        <composable_lifecycle_node pkg="composition"
+                                                   plugin="composition::Talker"
+                                                   autostart="true" />
+                    </node_container>
+                </launch>
+                """
+            ),
+            id='XML',
+        ),
+    ],
+)
+def test_composable_lifecycle_node_name_is_required(file):
+    root_entity, parser = Parser.load(io.StringIO(file))
+    with pytest.raises(ValueError, match='Composable lifecycle nodes require a name'):
+        parser.parse_description(root_entity)
 
 
 def _make_container_yaml(args='', thread_num=None):


### PR DESCRIPTION
## Summary
- make the regular composable node `name` attribute optional in the shared XML/YAML parser, matching the Python `ComposableNode` API
- omit the constructor argument when no name is provided so the component plugin can use its default name
- allow unnamed composable lifecycle nodes when autostart is omitted or explicitly disabled
- continue requiring a lifecycle node name when autostart is enabled or substitution-driven, because lifecycle event handling starts before the container returns the actual default name
- add XML and YAML regression coverage for the supported and rejected cases

## Testing
- reproduced the regular composable node missing-`name` `AttributeError` with both real launch frontends
- reproduced the original unconditional lifecycle-name rejection with autostart disabled
- focused real frontend probe: XML/YAML omitted and explicit-false lifecycle autostart cases accepted; both true cases rejected
- `ament_flake8` on both follow-up files
- `ament_pep257` on both follow-up files
- `ament_copyright` on both follow-up files
- `python -m py_compile` on both follow-up files
- `git diff --check`

The repository-native frontend test was not run locally because this Windows environment does not have the compiled ROS message packages or `rclpy`. The focused probes used the real `launch_xml` and `launch_yaml` frontends and replaced only the unavailable ROS import boundary.