### PR TITLE
Skip autostart for conditionally skipped lifecycle components

### DIFF
--- a/launch_ros/launch_ros/actions/load_composable_nodes.py
+++ b/launch_ros/launch_ros/actions/load_composable_nodes.py
@@ -257,25 +257,26 @@ class LoadComposableNodes(Action):
             if request is not None:
                 load_node_requests.append(request)
 
-            # If autostart is enabled, transition to the 'active' state.
-            if hasattr(node_description, 'node_autostart') and \
-               type_utils.perform_typed_substitution(
-                    context, node_description.node_autostart, bool):
-                node_namespace = request.node_namespace
-                if node_namespace[-1] != '/':
-                    node_namespace += '/'
-                complete_node_name = node_namespace + request.node_name
-                if not complete_node_name.startswith('/'):
-                    complete_node_name = '/' + complete_node_name
-                self.__logger.info(
-                    'Autostart enabled for requested lifecycle node {}'.format(complete_node_name))
-                node_description.init_lifecycle_event_manager(context)
-                autostart_actions.append(
-                    LifecycleTransition(
-                        lifecycle_node_names=[complete_node_name],
-                        transition_ids=[lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE,
-                                        lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE]
-                    ))
+                # If autostart is enabled, transition to the 'active' state.
+                if hasattr(node_description, 'node_autostart') and \
+                   type_utils.perform_typed_substitution(
+                        context, node_description.node_autostart, bool):
+                    node_namespace = request.node_namespace
+                    if node_namespace[-1] != '/':
+                        node_namespace += '/'
+                    complete_node_name = node_namespace + request.node_name
+                    if not complete_node_name.startswith('/'):
+                        complete_node_name = '/' + complete_node_name
+                    self.__logger.info(
+                        'Autostart enabled for requested lifecycle node {}'.format(
+                            complete_node_name))
+                    node_description.init_lifecycle_event_manager(context)
+                    autostart_actions.append(
+                        LifecycleTransition(
+                            lifecycle_node_names=[complete_node_name],
+                            transition_ids=[lifecycle_msgs.msg.Transition.TRANSITION_CONFIGURE,
+                                            lifecycle_msgs.msg.Transition.TRANSITION_ACTIVATE]
+                        ))
 
         if load_node_requests:
             context.add_completion_future(

--- a/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
@@ -26,6 +26,7 @@ from launch.conditions import IfCondition
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.actions import PushROSNamespace
 from launch_ros.actions import SetRemap
+from launch_ros.descriptions import ComposableLifecycleNode
 from launch_ros.descriptions import ComposableNode
 from launch_ros.utilities import get_node_name_count
 
@@ -161,12 +162,27 @@ def test_load_node_with_conditions(mock_component_container):
             name='test_node_name_false',
             namespace='test_node_namespace',
             condition=IfCondition('False')
-        )
+        ),
+        LoadComposableNodes(
+            target_container=f'/{TEST_CONTAINER_NAME}',
+            composable_node_descriptions=[
+                ComposableLifecycleNode(
+                    package='foo_package',
+                    plugin='bar_plugin',
+                    name='test_lifecycle_node_name_false',
+                    namespace='test_node_namespace',
+                    condition=IfCondition('False'),
+                    autostart=True,
+                )
+            ],
+        ),
     ])
 
     # Check that launch is aware of loaded component
     assert get_node_name_count(context, '/test_node_namespace/test_node_name_true') == 1
     assert get_node_name_count(context, '/test_node_namespace/test_node_name_false') == 0
+    assert get_node_name_count(
+        context, '/test_node_namespace/test_lifecycle_node_name_false') == 0
 
     # Check that container received correct request
     assert len(mock_component_container.requests) == 1


### PR DESCRIPTION
## Summary

- keep lifecycle autostart handling scoped to composable nodes that produced a load request
- avoid dereferencing an absent request when a composable lifecycle node condition is false
- cover `condition=False` together with `autostart=True`

## Testing

- focused source behavior probe: baseline raises `AttributeError` and the fixed code completes without scheduling the filtered node
- `python -m py_compile` for both modified Python files
- flake8 on both modified files with the repository's existing E501/W504 exclusions
- `git diff --check`