### PR TITLE
Support iterable inputs in LifecycleTransition

### DIFF
--- a/launch_ros/launch_ros/actions/lifecycle_transition.py
+++ b/launch_ros/launch_ros/actions/lifecycle_transition.py
@@ -75,10 +75,12 @@ class LifecycleTransition(Action):
         :param transitions_ids: The transitions to be executed.
         """
         super().__init__(**kwargs)
-        if len(transition_ids) == 0:
+        transition_ids = list(transition_ids)
+        lifecycle_node_names = list(lifecycle_node_names)
+        if not transition_ids:
             raise ValueError('No transition_ids provided.')
 
-        if len(lifecycle_node_names) == 0:
+        if not lifecycle_node_names:
             raise ValueError('No lifecycle_node_names provided.')
 
         self.__lifecycle_node_names = [

--- a/test_launch_ros/test/test_launch_ros/actions/test_lifecycle_transition.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_lifecycle_transition.py
@@ -38,11 +38,11 @@ def test_lifecycle_transition_constructor():
     with pytest.raises(ValueError):
         LifecycleTransition(
             lifecycle_node_names=['talker'],
-            transition_ids=[]
+            transition_ids=iter(())
         )
     with pytest.raises(ValueError):
         LifecycleTransition(
-            lifecycle_node_names=[],
+            lifecycle_node_names=iter(()),
             transition_ids=[Transition.TRANSITION_ACTIVATE]
         )
 
@@ -50,8 +50,8 @@ def test_lifecycle_transition_constructor():
 def test_lifecycle_transition_execute():
     lc = LaunchContext()
     lt = LifecycleTransition(
-        lifecycle_node_names=['talker'],
-        transition_ids=['1']
+        lifecycle_node_names=iter(['talker']),
+        transition_ids=iter(['1'])
     )
     actions = lt.execute(lc)
     # Check that actions are correctly generated


### PR DESCRIPTION
## Summary

- materialize `LifecycleTransition` iterable inputs once before validation
- support generators and iterators as promised by the public `Iterable` annotations
- keep the existing empty-input `ValueError` behavior for iterator inputs

## Testing

- focused source behavior probe: baseline raises `TypeError` for iterators, while the fixed constructor accepts them
- verified empty iterators still raise the existing field-specific `ValueError`
- `python -m py_compile` for both modified Python files
- flake8 on both modified files with the repository's existing E501/W504 exclusions
- `git diff --check`