### PR TITLE
Support iterable ROS arguments in Node

### DIFF
--- a/launch_ros/launch_ros/actions/node.py
+++ b/launch_ros/launch_ros/actions/node.py
@@ -200,7 +200,7 @@ class Node(ExecuteProcess):
         else:
             cmd = [executable]
         cmd += [] if arguments is None else arguments
-        cmd += [] if ros_arguments is None else ['--ros-args'] + ros_arguments
+        cmd += [] if ros_arguments is None else ['--ros-args'] + list(ros_arguments)
         # Reserve space for ros specific arguments.
         # The substitutions will get expanded when the action is executed.
         cmd += ['--ros-args']  # Prepend ros specific arguments with --ros-args flag

--- a/test_launch_ros/test/test_launch_ros/actions/test_node.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_node.py
@@ -96,7 +96,7 @@ class TestNode(unittest.TestCase):
 
     def test_launch_node_with_ros_arguments(self):
         node_action = self._create_node(
-            ros_arguments=['--log-level', 'debug', '--log-file-name', 'filename'])
+            ros_arguments=iter(['--log-level', 'debug', '--log-file-name', 'filename']))
         self._assert_launch_no_errors([node_action])
 
         cmd_string = ' '.join(node_action.process_details['cmd'])


### PR DESCRIPTION
## Summary

- materialize `Node.ros_arguments` at the command construction boundary
- support generators, iterators, tuples, and other finite iterables promised by the public annotation
- run the existing ROS argument launch test with an iterator

## Testing

- focused expression probe: baseline list concatenation raises `TypeError` for an iterator, while the fixed expression preserves argument order
- `python -m py_compile` for both modified Python files
- flake8 on both modified files with the repository's existing E501/W504 exclusions
- `git diff --check`