### PR TITLE
Fix string representations for untyped parameters

### DIFF
--- a/launch_ros/launch_ros/parameter_descriptions.py
+++ b/launch_ros/launch_ros/parameter_descriptions.py
@@ -81,9 +81,10 @@ class ParameterValue:
         return self.__value_type
 
     def __str__(self) -> Text:
+        value_type_name = self.value_type.__name__ if self.value_type is not None else None
         return (
             'launch_ros.description.ParameterValue'
-            f'(value={self.value}, value_type={self.value_type.__name__})'
+            f'(value={self.value}, value_type={value_type_name})'
         )
 
     def evaluate(self, context: LaunchContext) -> 'EvaluatedParameterValue':
@@ -146,9 +147,10 @@ class Parameter:
         return self.__parameter_value.value_type
 
     def __str__(self) -> Text:
+        value_type_name = self.value_type.__name__ if self.value_type is not None else None
         return (
             'launch_ros.description.Parameter'
-            f'(name={self.name}, value={self.value}, value_type={self.value_type.__name__})'
+            f'(name={self.name}, value={self.value}, value_type={value_type_name})'
         )
 
     def evaluate(self, context: LaunchContext) -> Tuple[Text, 'EvaluatedParameterValue']:

--- a/test_launch_ros/test/test_launch_ros/descriptions/test_parameter.py
+++ b/test_launch_ros/test/test_launch_ros/descriptions/test_parameter.py
@@ -40,6 +40,7 @@ def test_parameter_value_description():
     param = ParameterValue(value='asd')
     assert param.value == 'asd'
     assert param.value_type is None
+    assert str(param) == 'launch_ros.description.ParameterValue(value=asd, value_type=None)'
     assert param.evaluate(lc) == 'asd'
     # After the first `evaluate` call, the following `.value` and `.evaluate()`
     # calls are calculated differently. Test them too.
@@ -107,6 +108,8 @@ def test_parameter_description():
     assert param.value == 'asd'
     assert param.value_type is None
     assert param.evaluate(lc) == ('my_param', 'asd')
+    assert str(param) == (
+        'launch_ros.description.Parameter(name=my_param, value=asd, value_type=None)')
     # After the first `evaluate` call, the following `.name` `.value` and `.evaluate()`
     # calls are calculated differently. Test them too.
     assert param.name == 'my_param'


### PR DESCRIPTION
## Summary

- handle the default `value_type=None` in parameter description string representations
- preserve existing type names when an explicit type is configured
- cover both `ParameterValue` and `Parameter`

## Testing

- focused source behavior probe: both baseline classes raise `AttributeError`, while the fixed classes render the default type as `None`
- isolated class-level probes cover `None`, scalar `int` / `str`, and all four supported `typing.List[...]` value types
- `ament_flake8`, `ament_pep257`, and `ament_copyright` on both modified files
- `python -m py_compile` on both modified files
- `git diff --check`
- repository-native pytest is unavailable on this host because the compiled `lifecycle_msgs` package is not installed