### PR TITLE
Add RMW isolation to test_launch_ros tests

### DIFF
--- a/test_launch_ros/package.xml
+++ b/test_launch_ros/package.xml
@@ -25,6 +25,7 @@
   <test_depend>composition</test_depend>
   <test_depend>demo_nodes_py</test_depend>
   <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>launch_xml</test_depend>
   <test_depend>launch_yaml</test_depend>
   <test_depend>lifecycle</test_depend>
@@ -34,6 +35,7 @@
   <test_depend>python3-yaml</test_depend>
   <test_depend>rclcpp_components</test_depend>
   <test_depend>rclpy</test_depend>
+  <test_depend>rmw_test_fixture_implementation</test_depend>
   <test_depend>rosgraph_msgs</test_depend>
 
   <export>

--- a/test_launch_ros/test/test_launch_ros/actions/test_composable_node_container.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_composable_node_container.py
@@ -25,6 +25,8 @@ from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 from launch_ros.utilities import get_node_name_count
 
+from launch_testing_ros.actions import EnableRmwIsolation
+
 import osrf_pycommon.process_utils
 
 TEST_CONTAINER_NAME = 'test_component_container_node_name'
@@ -34,7 +36,7 @@ TEST_NODE_NAMESPACE = 'test_composable_node_namespace'
 
 
 def _assert_launch_no_errors(actions, *, timeout_sec=5):
-    ld = LaunchDescription(actions)
+    ld = LaunchDescription([EnableRmwIsolation(), *actions])
     ls = LaunchService(debug=True)
     ls.include_launch_description(ld)
 

--- a/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_load_composable_nodes.py
@@ -38,6 +38,8 @@ import rclpy.context
 import rclpy.executors
 import rclpy.node
 
+from rmw_test_fixture_implementation import RMWTestIsolator
+
 TEST_CONTAINER_NAME = 'mock_component_container'
 TEST_NODE_NAME = 'test_load_composable_nodes_node'
 
@@ -103,20 +105,21 @@ def _load_composable_node(
 
 @pytest.fixture
 def mock_component_container():
-    context = rclpy.context.Context()
-    with rclpy.init(context=context):
-        executor = rclpy.executors.SingleThreadedExecutor(context=context)
+    with RMWTestIsolator():
+        context = rclpy.context.Context()
+        with rclpy.init(context=context):
+            executor = rclpy.executors.SingleThreadedExecutor(context=context)
 
-        container = MockComponentContainer(context)
-        executor.add_node(container)
+            container = MockComponentContainer(context)
+            executor.add_node(container)
 
-        # Start spinning in a thread
-        thread = threading.Thread(target=lambda executor: executor.spin(), args=(executor,))
-        thread.start()
-        yield container
-        executor.remove_node(container)
-        executor.shutdown()
-        thread.join()
+            # Start spinning in a thread
+            thread = threading.Thread(target=lambda executor: executor.spin(), args=(executor,))
+            thread.start()
+            yield container
+            executor.remove_node(container)
+            executor.shutdown()
+            thread.join()
 
 
 def test_load_node(mock_component_container):

--- a/test_launch_ros/test/test_launch_ros/actions/test_ros_timer.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_ros_timer.py
@@ -28,6 +28,7 @@ from launch_ros.actions import SetUseSimTime
 import pytest
 import rclpy
 from rclpy.clock import Clock, ClockType
+from rmw_test_fixture_implementation import RMWTestIsolator
 from rosgraph_msgs.msg import Clock as ClockMsg
 
 
@@ -151,7 +152,7 @@ def test_shutdown_preempts_timers():
 
 @pytest.fixture
 def rclpy_node():
-    with rclpy.init():
+    with RMWTestIsolator(), rclpy.init():
         node = rclpy.create_node('test_ros_timer_action_node')
         yield node
 

--- a/test_launch_ros/test/test_launch_ros/frontend/test_component_container.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_component_container.py
@@ -17,10 +17,12 @@ import asyncio
 import io
 import textwrap
 
+from launch import LaunchDescription
 from launch import LaunchService
 from launch.frontend import Parser
 from launch.utilities import perform_substitutions
 from launch_ros.utilities import evaluate_parameters
+from launch_testing_ros.actions import EnableRmwIsolation
 import osrf_pycommon.process_utils
 import pytest
 
@@ -174,6 +176,7 @@ def test_launch_container_executor_modes(file_factory, container_args):
         root_entity, parser = Parser.load(f)
         ld = parser.parse_description(root_entity)
         ls = LaunchService()
+        ls.include_launch_description(LaunchDescription([EnableRmwIsolation()]))
         ls.include_launch_description(ld)
 
         loop = osrf_pycommon.process_utils.get_loop()
@@ -196,6 +199,7 @@ def check_launch_component_container(file):
     root_entity, parser = Parser.load(file)
     ld = parser.parse_description(root_entity)
     ls = LaunchService()
+    ls.include_launch_description(LaunchDescription([EnableRmwIsolation()]))
     ls.include_launch_description(ld)
 
     loop = osrf_pycommon.process_utils.get_loop()

--- a/test_launch_ros/test/test_launch_ros/frontend/test_lifecycle_node_frontend.py
+++ b/test_launch_ros/test/test_launch_ros/frontend/test_lifecycle_node_frontend.py
@@ -17,11 +17,13 @@ import io
 import pathlib
 import textwrap
 
+from launch import LaunchDescription
 from launch import LaunchService
 from launch.frontend import Parser
 from launch.utilities import type_utils
 from launch_ros.actions import LifecycleNode
 from launch_ros.utilities import evaluate_parameters
+from launch_testing_ros.actions import EnableRmwIsolation
 import osrf_pycommon.process_utils
 
 yaml_params = str(pathlib.Path(__file__).parent / 'params.yaml')
@@ -105,6 +107,7 @@ def check_launch_lifecycle_node(file):
     root_entity, parser = Parser.load(file)
     ld = parser.parse_description(root_entity)
     ls = LaunchService()
+    ls.include_launch_description(LaunchDescription([EnableRmwIsolation()]))
     ls.include_launch_description(ld)
 
     loop = osrf_pycommon.process_utils.get_loop()

--- a/test_launch_ros/test/test_launch_ros/utilities/test_track_node_names.py
+++ b/test_launch_ros/test/test_launch_ros/utilities/test_track_node_names.py
@@ -27,6 +27,8 @@ from launch_ros.descriptions.composable_node import ComposableNode
 from launch_ros.utilities import add_node_name
 from launch_ros.utilities import get_node_name_count
 
+from launch_testing_ros.actions import EnableRmwIsolation
+
 import osrf_pycommon.process_utils
 
 TEST_NODE_NAMESPACE = '/my_namespace'
@@ -46,6 +48,7 @@ def test_node_name_count():
 def _launch(launch_description):
     loop = osrf_pycommon.process_utils.get_loop()
     ls = LaunchService()
+    ls.include_launch_description(LaunchDescription([EnableRmwIsolation()]))
     ls.include_launch_description(launch_description)
     launch_task = loop.create_task(ls.run_async())
     loop.run_until_complete(asyncio.sleep(5))


### PR DESCRIPTION
## Description

Addresses parts of https://github.com/ros2/rmw_zenoh/issues/1016

### Is this user-facing behavior change?

No

### Did you use Generative AI?

Yes Claude Sonnet 5 to identify tests that require isolation.


### Additional Information

Test with `RMW_IMPLEMENTATION=rmw_zenoh_cpp colcon test --packages-select test_launch_ros`