### PR TITLE
Disable Fast DDS shared memory transport on Windows

### DIFF
--- a/test_launch_ros/test/conftest.py
+++ b/test_launch_ros/test/conftest.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test configuration for test_launch_ros."""
+
+import os
+import sys
+
+# Opening a shared memory segment left inconsistent by an abruptly terminated
+# peer faults inside Fast DDS. See
+# https://github.com/ros2/launch_ros/issues/539
+if sys.platform == 'win32':
+    os.environ.setdefault('FASTDDS_BUILTIN_TRANSPORTS', 'UDPv4')


### PR DESCRIPTION
Opening a shared memory segment left inconsistent by an abruptly terminated peer faults inside `SharedMemGlobal::open_port_internal`, killing the test process with an access violation (0xC0000005).

`check_sanity()` walks the allocator red-black tree through pointers stored in the segment. The fault is not a C++ exception, so the surrounding `catch (std::exception&)` does not intercept it.

Workaround for #539; root cause is upstream in Fast DDS.

Yes I used AI, and it hates using the pull request template