### PR TITLE
test: add regression test for isolated component_container load race

### DIFF
--- a/test_launch_ros/test/test_launch_ros/actions/test_isolated_container_load_race.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_isolated_container_load_race.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Dexory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Regression test for the isolated component_container load race.
+
+Starts several isolated ``component_container`` processes concurrently, each
+loading a composable node. The load clients are already waiting when their
+container starts, which exercises the window where the isolated container path
+briefly advertises a throwaway ``ComponentManager`` (owning
+``~/_container/load_node``) while reading the ``thread_num`` parameter and then
+destroys it before creating the real manager. A load request arriving during
+that window must not be dropped: every composable node is expected to appear.
+"""
+
+import asyncio
+
+from launch import LaunchDescription
+from launch import LaunchService
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+from launch_ros.utilities import get_node_name_count
+
+import osrf_pycommon.process_utils
+
+# Several containers started at once make the startup race easy to hit.
+NUM_CONTAINERS = 8
+
+
+def _assert_launch_no_errors(actions, *, timeout_sec=15):
+    ld = LaunchDescription(actions)
+    ls = LaunchService(debug=True)
+    ls.include_launch_description(ld)
+
+    loop = osrf_pycommon.process_utils.get_loop()
+    launch_task = loop.create_task(ls.run_async())
+    loop.run_until_complete(asyncio.sleep(timeout_sec))
+    if not launch_task.done():
+        loop.create_task(ls.shutdown())
+        loop.run_until_complete(launch_task)
+    assert 0 == launch_task.result()
+    return ls.context
+
+
+def test_isolated_container_load_race():
+    """All composables must load across several concurrent isolated containers."""
+    actions = []
+    for i in range(NUM_CONTAINERS):
+        actions.append(
+            ComposableNodeContainer(
+                package='rclcpp_components',
+                executable='component_container',
+                arguments=['--executor-type', 'single-threaded', '--isolated'],
+                name=f'test_isolated_container_{i}',
+                namespace='',
+                composable_node_descriptions=[
+                    ComposableNode(
+                        package='composition',
+                        plugin='composition::Listener',
+                        name=f'loaded_component_{i}',
+                        namespace='',
+                    )
+                ],
+            )
+        )
+
+    context = _assert_launch_no_errors(actions)
+
+    for i in range(NUM_CONTAINERS):
+        assert get_node_name_count(context, f'/test_isolated_container_{i}') == 1
+        assert get_node_name_count(context, f'/loaded_component_{i}') == 1

--- a/test_launch_ros/test/test_launch_ros/actions/test_isolated_container_load_race.py
+++ b/test_launch_ros/test/test_launch_ros/actions/test_isolated_container_load_race.py
@@ -13,15 +13,12 @@
 # limitations under the License.
 
 """
-Regression test for the isolated component_container load race.
+Regression test for concurrent isolated component_container node loading.
 
 Starts several isolated ``component_container`` processes concurrently, each
-loading a composable node. The load clients are already waiting when their
-container starts, which exercises the window where the isolated container path
-briefly advertises a throwaway ``ComponentManager`` (owning
-``~/_container/load_node``) while reading the ``thread_num`` parameter and then
-destroys it before creating the real manager. A load request arriving during
-that window must not be dropped: every composable node is expected to appear.
+loading a composable node whose load request is issued as the container starts
+up. Every container and every composable node is expected to come up: no load
+request may be dropped, regardless of startup timing.
 """
 
 import asyncio
@@ -34,7 +31,7 @@ from launch_ros.utilities import get_node_name_count
 
 import osrf_pycommon.process_utils
 
-# Several containers started at once make the startup race easy to hit.
+# Several containers started at once make a potential startup race easy to hit.
 NUM_CONTAINERS = 8
 
 


### PR DESCRIPTION
## Description

This PR adds a test for loading multiple  isolated component_container concurrently. My aim with this is: 
 1- surface a race condition bug (see discussion https://github.com/ros2/launch_ros/pull/563#issue-5121876755)
 2- After we fix the race condition, this test should stay as a regression test
 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
