### PR TITLE
Release ROS adapter resources during shutdown

### DIFF
--- a/launch_ros/launch_ros/ros_adapters.py
+++ b/launch_ros/launch_ros/ros_adapters.py
@@ -46,6 +46,7 @@ class ROSAdapter:
         self.__ros_context = None
         self.__ros_node = None
         self.__ros_executor = None
+        self.__ros_executor_thread = None
         self.__is_running = False
 
         if autostart:
@@ -86,8 +87,11 @@ class ROSAdapter:
             raise RuntimeError('Cannot shutdown a ROS adapter that is not running')
         self.__is_running = False
         self.__ros_executor_thread.join()
+        self.__ros_executor.shutdown()
         self.__ros_node.destroy_node()
         rclpy.shutdown(context=self.__ros_context)
+        self.__ros_executor_thread = None
+        self.__ros_node = None
 
     @property
     def argv(self):

--- a/launch_ros/test/test_ros_adapters.py
+++ b/launch_ros/test/test_ros_adapters.py
@@ -1,0 +1,39 @@
+# Copyright 2026 ktyang512
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+from launch_ros.ros_adapters import ROSAdapter
+
+
+def test_ros_adapter_shutdown_releases_resources():
+    adapter = ROSAdapter()
+    old_context = adapter.ros_context
+    old_executor = adapter.ros_executor
+
+    with patch.object(
+        adapter.ros_executor,
+        'shutdown',
+        wraps=adapter.ros_executor.shutdown,
+    ) as executor_shutdown:
+        adapter.shutdown()
+
+    executor_shutdown.assert_called_once_with()
+    assert adapter.ros_node is None
+
+    adapter.start()
+    assert adapter.ros_context is not old_context
+    assert adapter.ros_node is not None
+    assert adapter.ros_executor is not old_executor
+    adapter.shutdown()


### PR DESCRIPTION
## Description

Fixes #565.

`ROSAdapter.shutdown()` stopped its executor thread and shut down its node and
context, but it retained the node wrapper and did not shut down the executor
itself. In repeated launch tests, the retained rclpy/Fast DDS resources were
only released by delayed cyclic garbage collection, so file descriptors and DDS
threads accumulated until another file or pipe creation failed with `EMFILE`.

This change explicitly shuts down the executor and releases the adapter's node
and private thread references after shutdown. It also adds a regression
covering executor cleanup, node release, and restart with fresh resources.

### Is this user-facing behavior change?

After `ROSAdapter.shutdown()`, its `ros_node` property now returns `None`
instead of a destroyed node. The stopped context and executor remain
inspectable, and calling `start()` replaces all three with fresh objects.

### Did you use Generative AI?

Yes. OpenAI Codex (GPT-5) assisted with candidate research, reproduction,
diagnosis, implementation, test design, and drafting. I reviewed the final diff
and validation evidence before submission.

### Additional Information

Local validation on Rolling with Fast DDS:

- the focused regression fails against the previous implementation and passes
  with this change;
- all 5 `launch_ros/test` tests pass, including copyright, flake8, and pep257;
- all 22 YAML/XML and executor-mode cases in
  `test_launch_container_executor_modes` pass under `ulimit -n 64` in 118.59
  seconds, with file descriptors and threads stable at 11 and 8 after every
  case;
- `git diff --check` passes.

Not tested locally: the full multi-package repository suite, ROS buildfarm
jobs, Windows, aarch64, or non-Fast-DDS RMW implementations.
