### PR TITLE
Enable rmw test isolation

### DIFF
--- a/test_launch_ros/conftest.py
+++ b/test_launch_ros/conftest.py
@@ -1,0 +1,34 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+try:
+    from rmw_test_fixture_implementation import rmw_test_isolation_start
+    from rmw_test_fixture_implementation import rmw_test_isolation_stop
+    _HAS_RMW_ISOLATION = True
+except ImportError:
+    _HAS_RMW_ISOLATION = False
+
+
+@pytest.fixture(autouse=True, scope='session')
+def rmw_isolation():
+    """
+    Start RMW isolation for the whole test session.
+    """
+    if _HAS_RMW_ISOLATION:
+        rmw_test_isolation_start()
+    yield
+    if _HAS_RMW_ISOLATION:
+        rmw_test_isolation_stop()

--- a/test_launch_ros/conftest.py
+++ b/test_launch_ros/conftest.py
@@ -13,22 +13,13 @@
 # limitations under the License.
 
 import pytest
-
-try:
-    from rmw_test_fixture_implementation import rmw_test_isolation_start
-    from rmw_test_fixture_implementation import rmw_test_isolation_stop
-    _HAS_RMW_ISOLATION = True
-except ImportError:
-    _HAS_RMW_ISOLATION = False
+from rmw_test_fixture_implementation import rmw_test_isolation_start
+from rmw_test_fixture_implementation import rmw_test_isolation_stop
 
 
 @pytest.fixture(autouse=True, scope='session')
 def rmw_isolation():
-    """
-    Start RMW isolation for the whole test session.
-    """
-    if _HAS_RMW_ISOLATION:
-        rmw_test_isolation_start()
+    """Start RMW isolation before any ROS context is created."""
+    rmw_test_isolation_start()
     yield
-    if _HAS_RMW_ISOLATION:
-        rmw_test_isolation_stop()
+    rmw_test_isolation_stop()

--- a/test_launch_ros/package.xml
+++ b/test_launch_ros/package.xml
@@ -34,6 +34,7 @@
   <test_depend>python3-yaml</test_depend>
   <test_depend>rclcpp_components</test_depend>
   <test_depend>rclpy</test_depend>
+  <test_depend>rmw_test_fixture_implementation</test_depend>
   <test_depend>rosgraph_msgs</test_depend>
 
   <export>


### PR DESCRIPTION
## Description

`test_launch_ros` never engaged `rmw_test_fixture`, so in-process ROS tests hung under `rmw_zenoh_cpp`. Nodes in separate `rclpy` contexts never discovered each other without an ad-hoc Zenoh router, `LoadComposableNodes` waited forever for the mock container’s `load_node` service, and pytest timed out without writing a result file (`pytest.missing_result`).

This adds a session-scoped autouse fixture in `test_launch_ros/conftest.py` that starts and stops RMW isolation before any ROS context is created, matching `ros2cli`’s [test_ros2cli_daemon.py](https://github.com/ros2/ros2cli/blob/7b47206ab04c27d4597c692240a68ac1f7059790/ros2cli/test/test_ros2cli_daemon.py#L32-L37). 

```
RMW_IMPLEMENTATION=rmw_zenoh_cpp colcon test --packages-select test_launch_ros --event-handlers console_direct+
```

Fixes # (issue)
The only failing nightly test with rmw_zenoh https://build.ros2.org/job/Rci__nightly-zenoh_ubuntu_resolute_amd64/117/testReport/

### Is this user-facing behavior change?

No. Test-only.

### Did you use Generative AI?

Yes. Cursor (Grok 4.6) was used to diagnose the hang and draft `test_launch_ros/conftest.py`.

### Additional Information